### PR TITLE
[Refactor/#6] 이벤트 발행 관련 테스트 개선

### DIFF
--- a/src/main/kotlin/com/manage/crm/email/application/BrowseEmailNotificationSchedulesUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/BrowseEmailNotificationSchedulesUseCase.kt
@@ -2,7 +2,7 @@ package com.manage.crm.email.application
 
 import com.manage.crm.email.application.dto.BrowseEmailNotificationSchedulesUseCaseOut
 import com.manage.crm.email.application.dto.EmailNotificationScheduleDto
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServiceImpl
 import com.manage.crm.support.out
 import org.springframework.stereotype.Service
 
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service
  */
 @Service
 class BrowseEmailNotificationSchedulesUseCase(
-    private val scheduleTaskService: ScheduleTaskService
+    private val scheduleTaskService: ScheduleTaskServiceImpl
 ) {
 
     suspend fun execute(): BrowseEmailNotificationSchedulesUseCaseOut {

--- a/src/main/kotlin/com/manage/crm/email/application/CancelNotificationEmailUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/CancelNotificationEmailUseCase.kt
@@ -2,12 +2,12 @@ package com.manage.crm.email.application
 
 import com.manage.crm.email.application.dto.CancelNotificationEmailUseCaseIn
 import com.manage.crm.email.application.dto.CancelNotificationEmailUseCaseOut
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import org.springframework.stereotype.Service
 
 @Service
 class CancelNotificationEmailUseCase(
-    private val scheduleTaskService: ScheduleTaskService
+    private val scheduleTaskService: ScheduleTaskServicePostEventProcessor
 ) {
 
     suspend fun execute(useCaseIn: CancelNotificationEmailUseCaseIn): CancelNotificationEmailUseCaseOut {

--- a/src/main/kotlin/com/manage/crm/email/application/DeleteTemplateUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/DeleteTemplateUseCase.kt
@@ -2,7 +2,7 @@ package com.manage.crm.email.application
 
 import com.manage.crm.email.application.dto.DeleteTemplateUseCaseIn
 import com.manage.crm.email.application.dto.DeleteTemplateUseCaseOut
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
 import com.manage.crm.email.domain.repository.ScheduledEventRepository
 import org.springframework.stereotype.Service
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 class DeleteTemplateUseCase(
     private val emailTemplateRepository: EmailTemplateRepository,
     private val scheduledEventRepository: ScheduledEventRepository,
-    private val scheduleTaskService: ScheduleTaskService
+    private val scheduleTaskService: ScheduleTaskServicePostEventProcessor
 ) {
     @Transactional
     suspend fun execute(useCaseIn: DeleteTemplateUseCaseIn): DeleteTemplateUseCaseOut {

--- a/src/main/kotlin/com/manage/crm/email/application/PostEmailNotificationSchedulesUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/PostEmailNotificationSchedulesUseCase.kt
@@ -3,7 +3,7 @@ package com.manage.crm.email.application
 import com.manage.crm.email.application.dto.NotificationEmailSendTimeOutEventInput
 import com.manage.crm.email.application.dto.PostEmailNotificationSchedulesUseCaseIn
 import com.manage.crm.email.application.dto.PostEmailNotificationSchedulesUseCaseOut
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.vo.EventId
 import com.manage.crm.support.out
 import org.springframework.stereotype.Service
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service
  */
 @Service
 class PostEmailNotificationSchedulesUseCase(
-    private val scheduleTaskService: ScheduleTaskService
+    private val scheduleTaskService: ScheduleTaskServicePostEventProcessor
 ) {
 
     suspend fun execute(useCaseIn: PostEmailNotificationSchedulesUseCaseIn): PostEmailNotificationSchedulesUseCaseOut {

--- a/src/main/kotlin/com/manage/crm/email/application/SendNotificationEmailUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/SendNotificationEmailUseCase.kt
@@ -2,10 +2,10 @@ package com.manage.crm.email.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.manage.crm.email.application.dto.NonContent
-import com.manage.crm.email.application.dto.SendEmailDto
+import com.manage.crm.email.application.dto.SendEmailInDto
 import com.manage.crm.email.application.dto.SendNotificationEmailUseCaseIn
 import com.manage.crm.email.application.dto.SendNotificationEmailUseCaseOut
-import com.manage.crm.email.application.service.NonVariablesMailService
+import com.manage.crm.email.application.service.NonVariablesMailServicePostEventProcessor
 import com.manage.crm.email.domain.model.NotificationEmailTemplatePropertiesModel
 import com.manage.crm.email.domain.repository.EmailTemplateHistoryRepository
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Service
 class SendNotificationEmailUseCase(
     private val emailTemplateRepository: EmailTemplateRepository,
     private val emailTemplateHistoryRepository: EmailTemplateHistoryRepository,
-    private val nonVariablesEmailService: NonVariablesMailService,
+    private val nonVariablesEmailService: NonVariablesMailServicePostEventProcessor,
     private val userRepository: UserRepository,
     private val objectMapper: ObjectMapper
 ) {
@@ -43,7 +43,7 @@ class SendNotificationEmailUseCase(
         // TODO: Send email asynchronously
         targetUsers.keys.forEach { email ->
             nonVariablesEmailService.send(
-                SendEmailDto(
+                SendEmailInDto(
                     to = email,
                     subject = notificationProperties.subject,
                     template = notificationProperties.body,

--- a/src/main/kotlin/com/manage/crm/email/application/dto/NonVariablesEmailServiceDto.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/dto/NonVariablesEmailServiceDto.kt
@@ -1,5 +1,6 @@
 package com.manage.crm.email.application.dto
 
+import com.manage.crm.email.domain.vo.EmailProviderType
 import com.manage.crm.email.domain.vo.SentEmailStatus
 import com.manage.crm.infrastructure.mail.SendMailArgs
 
@@ -13,7 +14,7 @@ data class SendEmailArgs(
     override val properties: String = ""
 ) : SendMailArgs<NonContent, String>
 
-data class SendEmailDto(
+data class SendEmailInDto(
     val to: String,
     val subject: String,
     val template: String,
@@ -25,5 +26,13 @@ data class SendEmailDto(
 ) {
     val emailArgs = SendEmailArgs(to, subject, template, content, properties)
 }
+
+data class SendEmailOutDto(
+    val userId: Long,
+    val emailBody: String,
+    val messageId: String,
+    val destination: String,
+    val provider: EmailProviderType
+)
 
 class NonVariablesEmailServiceDto

--- a/src/main/kotlin/com/manage/crm/email/application/service/NonVariablesMailService.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/service/NonVariablesMailService.kt
@@ -1,46 +1,8 @@
 package com.manage.crm.email.application.service
 
-import com.manage.crm.email.application.dto.SendEmailArgs
-import com.manage.crm.email.application.dto.SendEmailDto
-import com.manage.crm.email.domain.vo.EmailProviderType
-import com.manage.crm.email.event.send.EmailSentEvent
-import com.manage.crm.infrastructure.mail.MailContext
-import com.manage.crm.infrastructure.mail.MailSender
-import com.manage.crm.infrastructure.mail.MailTemplateProcessor
-import com.manage.crm.infrastructure.mail.MailTemplateType
-import com.manage.crm.infrastructure.mail.provider.MailSendProvider
-import com.manage.crm.user.domain.repository.UserRepository
-import org.springframework.boot.autoconfigure.mail.MailProperties
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.stereotype.Component
+import com.manage.crm.email.application.dto.SendEmailInDto
+import com.manage.crm.email.application.dto.SendEmailOutDto
 
-@Component
-class NonVariablesMailService(
-    private val userRepository: UserRepository,
-    private val mailTemplateProcessor: MailTemplateProcessor,
-    private val eventPublisher: ApplicationEventPublisher,
-    mailProperties: MailProperties,
-    mailSendProvider: MailSendProvider
-) : MailSender<SendEmailArgs>(mailProperties, mailSendProvider) {
-
-    override fun getHtml(args: SendEmailArgs): String {
-        val context = MailContext()
-        return mailTemplateProcessor.process(args.template, context, MailTemplateType.STRING)
-    }
-
-    suspend fun send(args: SendEmailDto) {
-        val emailArgs = args.emailArgs
-        send(emailArgs).let {
-            val userId = userRepository.findByEmail(args.to)?.id ?: throw IllegalArgumentException("User not found by email: ${args.to}")
-            eventPublisher.publishEvent(
-                EmailSentEvent(
-                    userId = userId,
-                    emailBody = args.emailBody,
-                    messageId = it,
-                    destination = args.destination,
-                    provider = EmailProviderType.AWS
-                )
-            )
-        }
-    }
+interface NonVariablesMailService {
+    suspend fun send(args: SendEmailInDto): SendEmailOutDto
 }

--- a/src/main/kotlin/com/manage/crm/email/application/service/NonVariablesMailServiceImpl.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/service/NonVariablesMailServiceImpl.kt
@@ -1,0 +1,43 @@
+package com.manage.crm.email.application.service
+
+import com.manage.crm.email.application.dto.SendEmailArgs
+import com.manage.crm.email.application.dto.SendEmailInDto
+import com.manage.crm.email.application.dto.SendEmailOutDto
+import com.manage.crm.email.domain.vo.EmailProviderType
+import com.manage.crm.infrastructure.mail.MailContext
+import com.manage.crm.infrastructure.mail.MailSender
+import com.manage.crm.infrastructure.mail.MailTemplateProcessor
+import com.manage.crm.infrastructure.mail.MailTemplateType
+import com.manage.crm.infrastructure.mail.provider.MailSendProvider
+import com.manage.crm.user.domain.repository.UserRepository
+import org.springframework.boot.autoconfigure.mail.MailProperties
+import org.springframework.stereotype.Component
+
+@Component
+class NonVariablesMailServiceImpl(
+    private val userRepository: UserRepository,
+    private val mailTemplateProcessor: MailTemplateProcessor,
+    mailProperties: MailProperties,
+    mailSendProvider: MailSendProvider
+) : MailSender<SendEmailArgs>(mailProperties, mailSendProvider), NonVariablesMailService {
+
+    override fun getHtml(args: SendEmailArgs): String {
+        val context = MailContext()
+        return mailTemplateProcessor.process(args.template, context, MailTemplateType.STRING)
+    }
+
+    override suspend fun send(args: SendEmailInDto): SendEmailOutDto {
+        val emailArgs = args.emailArgs
+        return send(emailArgs).let {
+            val userId = userRepository.findByEmail(args.to)?.id
+                ?: throw IllegalArgumentException("User not found by email: ${args.to}")
+            SendEmailOutDto(
+                userId = userId,
+                emailBody = args.emailBody,
+                messageId = it,
+                destination = args.destination,
+                provider = EmailProviderType.AWS
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/manage/crm/email/application/service/NonVariablesMailServicePostEventProcessor.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/service/NonVariablesMailServicePostEventProcessor.kt
@@ -1,0 +1,31 @@
+package com.manage.crm.email.application.service
+
+import com.manage.crm.email.application.dto.SendEmailInDto
+import com.manage.crm.email.application.dto.SendEmailOutDto
+import com.manage.crm.email.event.send.EmailSentEvent
+import com.manage.crm.email.support.EmailEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class NonVariablesMailServicePostEventProcessor(
+    private val nonVariablesMailServiceImpl: NonVariablesMailServiceImpl,
+    private val emailEventPublisher: EmailEventPublisher
+) : NonVariablesMailService {
+
+    override suspend fun send(args: SendEmailInDto): SendEmailOutDto {
+        return sendPostEventProcess(nonVariablesMailServiceImpl.send(args))
+    }
+
+    fun sendPostEventProcess(outDto: SendEmailOutDto): SendEmailOutDto {
+        emailEventPublisher.publishEvent(
+            EmailSentEvent(
+                userId = outDto.userId,
+                emailBody = outDto.emailBody,
+                messageId = outDto.messageId,
+                destination = outDto.destination,
+                provider = outDto.provider
+            )
+        )
+        return outDto
+    }
+}

--- a/src/main/kotlin/com/manage/crm/email/application/service/ScheduleTaskService.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/service/ScheduleTaskService.kt
@@ -1,81 +1,9 @@
 package com.manage.crm.email.application.service
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.manage.crm.email.application.dto.NotificationEmailSendTimeOutEventInput
-import com.manage.crm.email.application.dto.ScheduleTaskView
-import com.manage.crm.email.domain.repository.ScheduledEventRepository
-import com.manage.crm.email.domain.vo.EventId
-import com.manage.crm.email.event.schedule.CancelScheduledEvent
-import com.manage.crm.email.event.send.notification.NotificationEmailSendTimeOutEvent
-import com.manage.crm.infrastructure.scheduler.ScheduleName
-import com.manage.crm.infrastructure.scheduler.provider.AwsSchedulerService
-import com.manage.crm.support.parseISOExpiredTime
-import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.stereotype.Component
 
-@Component
-class ScheduleTaskService(
-    private val scheduledEventRepository: ScheduledEventRepository,
-    private val awsSchedulerService: AwsSchedulerService,
-    private val objectMapper: ObjectMapper,
-    private val applicationEventPublisher: ApplicationEventPublisher
-) {
-    val log = KotlinLogging.logger {}
-
-    fun newSchedule(input: NotificationEmailSendTimeOutEventInput): String {
-        awsSchedulerService.createSchedule(
-            name = input.eventId.value,
-            schedule = input.expiredTime,
-            input = input
-        )
-
-        applicationEventPublisher.publishEvent(
-            NotificationEmailSendTimeOutEvent(
-                eventId = input.eventId,
-                templateId = input.templateId,
-                templateVersion = input.templateVersion,
-                userIds = input.userIds,
-                expiredTime = input.expiredTime
-            )
-        )
-        return input.eventId.value
-    }
-
-    fun cancel(scheduleName: String) {
-        awsSchedulerService.deleteSchedule(ScheduleName(scheduleName))
-        applicationEventPublisher.publishEvent(
-            CancelScheduledEvent(
-                scheduledEventId = EventId(scheduleName)
-            )
-        )
-        log.info { "Task $scheduleName is cancelled" }
-    }
-
-    fun reSchedule(input: NotificationEmailSendTimeOutEventInput) {
-        cancel(input.eventId.value)
-        newSchedule(input)
-    }
-
-    suspend fun browseScheduledTasksView(): List<ScheduleTaskView> {
-        val awsScheduleViews = awsSchedulerService.browseSchedule()
-            .map { EventId(it.value) }
-            .filter { it.value.matches(Regex("[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}")) }
-
-        return scheduledEventRepository
-            .findAllByEventIdIn(awsScheduleViews)
-            .map {
-                // TODO: refactor readValue to readTree
-                val payload = objectMapper.readValue(it.eventPayload, Map::class.java).toMutableMap()
-                payload["eventId"] = it.eventId?.value
-                payload
-            }.map { payload ->
-                ScheduleTaskView(
-                    taskName = payload["eventId"] as String,
-                    templateId = (payload["templateId"] as Int).toLong(),
-                    userIds = (payload["userIds"] as List<Int>).map { it.toLong() },
-                    expiredTime = (payload["expiredTime"] as String).parseISOExpiredTime()
-                )
-            }.toList()
-    }
+interface ScheduleTaskService {
+    fun newSchedule(input: NotificationEmailSendTimeOutEventInput): String
+    fun cancel(scheduleName: String)
+    fun reSchedule(input: NotificationEmailSendTimeOutEventInput)
 }

--- a/src/main/kotlin/com/manage/crm/email/application/service/ScheduleTaskServiceImpl.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/service/ScheduleTaskServiceImpl.kt
@@ -1,0 +1,63 @@
+package com.manage.crm.email.application.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.manage.crm.email.application.dto.NotificationEmailSendTimeOutEventInput
+import com.manage.crm.email.application.dto.ScheduleTaskView
+import com.manage.crm.email.domain.repository.ScheduledEventRepository
+import com.manage.crm.email.domain.vo.EventId
+import com.manage.crm.infrastructure.scheduler.ScheduleName
+import com.manage.crm.infrastructure.scheduler.provider.AwsSchedulerService
+import com.manage.crm.support.parseISOExpiredTime
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+@Component
+class ScheduleTaskServiceImpl(
+    private val scheduledEventRepository: ScheduledEventRepository,
+    private val awsSchedulerService: AwsSchedulerService,
+    private val objectMapper: ObjectMapper
+) : ScheduleTaskService {
+    val log = KotlinLogging.logger {}
+
+    override fun newSchedule(input: NotificationEmailSendTimeOutEventInput): String {
+        awsSchedulerService.createSchedule(
+            name = input.eventId.value,
+            schedule = input.expiredTime,
+            input = input
+        )
+        return input.eventId.value
+    }
+
+    override fun cancel(scheduleName: String) {
+        awsSchedulerService.deleteSchedule(ScheduleName(scheduleName))
+        log.info { "Task $scheduleName is cancelled" }
+    }
+
+    override fun reSchedule(input: NotificationEmailSendTimeOutEventInput) {
+        cancel(input.eventId.value)
+        newSchedule(input)
+    }
+
+    // todo refactor to interface
+    suspend fun browseScheduledTasksView(): List<ScheduleTaskView> {
+        val awsScheduleViews = awsSchedulerService.browseSchedule()
+            .map { EventId(it.value) }
+            .filter { it.value.matches(Regex("[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}")) }
+
+        return scheduledEventRepository
+            .findAllByEventIdIn(awsScheduleViews)
+            .map {
+                // TODO: refactor readValue to readTree
+                val payload = objectMapper.readValue(it.eventPayload, Map::class.java).toMutableMap()
+                payload["eventId"] = it.eventId?.value
+                payload
+            }.map { payload ->
+                ScheduleTaskView(
+                    taskName = payload["eventId"] as String,
+                    templateId = (payload["templateId"] as Int).toLong(),
+                    userIds = (payload["userIds"] as List<Int>).map { it.toLong() },
+                    expiredTime = (payload["expiredTime"] as String).parseISOExpiredTime()
+                )
+            }.toList()
+    }
+}

--- a/src/main/kotlin/com/manage/crm/email/application/service/ScheduleTaskServicePostEventProcessor.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/service/ScheduleTaskServicePostEventProcessor.kt
@@ -1,0 +1,61 @@
+package com.manage.crm.email.application.service
+
+import com.manage.crm.email.application.dto.NotificationEmailSendTimeOutEventInput
+import com.manage.crm.email.domain.vo.EventId
+import com.manage.crm.email.event.schedule.CancelScheduledEvent
+import com.manage.crm.email.event.send.notification.NotificationEmailSendTimeOutEvent
+import com.manage.crm.email.support.EmailEventPublisher
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+@Component
+class ScheduleTaskServicePostEventProcessor(
+    private val scheduleTaskServiceImpl: ScheduleTaskServiceImpl,
+    private val emailEventPublisher: EmailEventPublisher
+) : ScheduleTaskService {
+    val log = KotlinLogging.logger {}
+
+    override fun newSchedule(input: NotificationEmailSendTimeOutEventInput): String {
+        return newScheduleEventProcess(scheduleTaskServiceImpl.newSchedule(input), input)
+    }
+
+    override fun cancel(scheduleName: String) {
+        scheduleTaskServiceImpl.cancel(scheduleName).let {
+            cancelEventProcess(scheduleName)
+        }
+    }
+
+    override fun reSchedule(input: NotificationEmailSendTimeOutEventInput) {
+        scheduleTaskServiceImpl.reSchedule(input).let {
+            reScheduleEventProcess(input)
+        }
+    }
+
+    fun newScheduleEventProcess(
+        result: String,
+        input: NotificationEmailSendTimeOutEventInput
+    ): String {
+        emailEventPublisher.publishEvent(
+            NotificationEmailSendTimeOutEvent(
+                eventId = input.eventId,
+                templateId = input.templateId,
+                templateVersion = input.templateVersion,
+                userIds = input.userIds,
+                expiredTime = input.expiredTime
+            )
+        )
+        return result
+    }
+
+    fun cancelEventProcess(scheduleName: String) {
+        val cancelScheduledEvent = CancelScheduledEvent(
+            scheduledEventId = EventId(scheduleName)
+        )
+        emailEventPublisher.publishEvent(cancelScheduledEvent)
+    }
+
+    fun reScheduleEventProcess(input: NotificationEmailSendTimeOutEventInput) {
+        cancelEventProcess(input.eventId.value)
+        newScheduleEventProcess(input.eventId.value, input)
+    }
+}

--- a/src/main/kotlin/com/manage/crm/email/event/relay/aws/ScheduledEventReverseRelay.kt
+++ b/src/main/kotlin/com/manage/crm/email/event/relay/aws/ScheduledEventReverseRelay.kt
@@ -2,17 +2,17 @@ package com.manage.crm.email.event.relay.aws
 
 import com.manage.crm.email.event.relay.aws.mapper.ScheduledEventMessageMapper
 import com.manage.crm.email.event.send.notification.NotificationEmailSendTimeOutInvokeEvent
+import com.manage.crm.email.support.EmailEventPublisher
 import io.awspring.cloud.sqs.annotation.SqsListener
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Profile("!local && !test")
 @Component
 class ScheduledEventReverseRelay(
-    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val emailEventPublisher: EmailEventPublisher,
     private val scheduledEventMessageMapper: ScheduledEventMessageMapper
 ) {
     val log = KotlinLogging.logger { }
@@ -29,6 +29,6 @@ class ScheduledEventReverseRelay(
     }
 
     fun publish(event: NotificationEmailSendTimeOutInvokeEvent) {
-        applicationEventPublisher.publishEvent(event)
+        emailEventPublisher.publishEvent(event)
     }
 }

--- a/src/main/kotlin/com/manage/crm/email/event/relay/aws/SesMessageReverseRelay.kt
+++ b/src/main/kotlin/com/manage/crm/email/event/relay/aws/SesMessageReverseRelay.kt
@@ -2,17 +2,17 @@ package com.manage.crm.email.event.relay.aws
 
 import com.manage.crm.email.event.relay.aws.mapper.SesMessageMapper
 import com.manage.crm.email.event.send.EmailSendEvent
+import com.manage.crm.email.support.EmailEventPublisher
 import io.awspring.cloud.sqs.annotation.SqsListener
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Profile("!local && !test")
 @Component
 class SesMessageReverseRelay(
-    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val emailEventPublisher: EmailEventPublisher,
     private val eventMessageMapper: SesMessageMapper
 ) {
     val log = KotlinLogging.logger { }
@@ -30,6 +30,6 @@ class SesMessageReverseRelay(
     }
 
     fun publish(event: EmailSendEvent) {
-        applicationEventPublisher.publishEvent(event)
+        emailEventPublisher.publishEvent(event)
     }
 }

--- a/src/main/kotlin/com/manage/crm/email/event/send/handler/EmailDeliveryDelayEventHandler.kt
+++ b/src/main/kotlin/com/manage/crm/email/event/send/handler/EmailDeliveryDelayEventHandler.kt
@@ -11,6 +11,6 @@ class EmailDeliveryDelayEventHandler(
 ) {
     val log = KotlinLogging.logger {}
 
-    fun handle(event: EmailDeliveryDelayEvent) {
+    suspend fun handle(event: EmailDeliveryDelayEvent) {
     }
 }

--- a/src/main/kotlin/com/manage/crm/email/event/send/notification/handler/NotificationEmailSendTimeOutInvokeEventHandler.kt
+++ b/src/main/kotlin/com/manage/crm/email/event/send/notification/handler/NotificationEmailSendTimeOutInvokeEventHandler.kt
@@ -3,7 +3,7 @@ package com.manage.crm.email.event.send.notification.handler
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.manage.crm.email.application.dto.NonContent
 import com.manage.crm.email.application.dto.SendEmailArgs
-import com.manage.crm.email.application.service.NonVariablesMailService
+import com.manage.crm.email.application.service.NonVariablesMailServiceImpl
 import com.manage.crm.email.domain.EmailSendHistory
 import com.manage.crm.email.domain.model.NotificationEmailTemplatePropertiesModel
 import com.manage.crm.email.domain.repository.EmailSendHistoryRepository
@@ -25,7 +25,7 @@ class NotificationEmailSendTimeOutInvokeEventHandler(
     private val emailTemplateHistoryRepository: EmailTemplateHistoryRepository,
     private val emailSendHistoryRepository: EmailSendHistoryRepository,
     private val userRepository: UserRepository,
-    private val nonVariablesEmailService: NonVariablesMailService,
+    private val nonVariablesEmailService: NonVariablesMailServiceImpl,
     private val objectMapper: ObjectMapper,
     private val transactionalTemplates: TransactionTemplates
 ) {

--- a/src/main/kotlin/com/manage/crm/email/support/EmailEventPublisher.kt
+++ b/src/main/kotlin/com/manage/crm/email/support/EmailEventPublisher.kt
@@ -1,0 +1,34 @@
+package com.manage.crm.email.support
+
+import com.manage.crm.email.event.schedule.CancelScheduledEvent
+import com.manage.crm.email.event.send.EmailSendEvent
+import com.manage.crm.email.event.send.EmailSentEvent
+import com.manage.crm.email.event.send.notification.NotificationEmailSendTimeOutEvent
+import com.manage.crm.email.event.send.notification.NotificationEmailSendTimeOutInvokeEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class EmailEventPublisher(
+    val applicationEventPublisher: ApplicationEventPublisher
+) {
+    fun publishEvent(event: CancelScheduledEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    fun publishEvent(event: NotificationEmailSendTimeOutEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    fun publishEvent(event: EmailSendEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    fun publishEvent(event: NotificationEmailSendTimeOutInvokeEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    fun publishEvent(event: EmailSentEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/src/test/kotlin/com/manage/crm/email/MailEventInvokeSituationTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/MailEventInvokeSituationTest.kt
@@ -18,7 +18,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
 abstract class MailEventInvokeSituationTest : EmailModuleTestTemplate() {
     // ----------------- CancelScheduledEventHandlerTest -----------------
-
     @MockitoBean
     lateinit var awsSchedulerService: AwsSchedulerService
 

--- a/src/test/kotlin/com/manage/crm/email/MailEventInvokeSituationTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/MailEventInvokeSituationTest.kt
@@ -1,6 +1,6 @@
 package com.manage.crm.email
 
-import com.manage.crm.email.application.service.NonVariablesMailService
+import com.manage.crm.email.application.service.NonVariablesMailServiceImpl
 import com.manage.crm.email.event.schedule.handler.CancelScheduledEventHandler
 import com.manage.crm.email.event.send.handler.EmailClickEventHandler
 import com.manage.crm.email.event.send.handler.EmailDeliveryDelayEventHandler
@@ -10,6 +10,7 @@ import com.manage.crm.email.event.send.handler.EmailSentEventHandler
 import com.manage.crm.email.event.send.notification.handler.NotificationEmailSendTimeOutEventHandler
 import com.manage.crm.email.event.send.notification.handler.NotificationEmailSendTimeOutInvokeEventHandler
 import com.manage.crm.email.event.template.handler.PostEmailTemplateEventHandler
+import com.manage.crm.email.support.EmailEventPublisher
 import com.manage.crm.infrastructure.scheduler.provider.AwsSchedulerService
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
@@ -17,6 +18,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
 abstract class MailEventInvokeSituationTest : EmailModuleTestTemplate() {
+    // ----------------- Common -----------------
+    @MockitoBean
+    lateinit var emailEventPublisher: EmailEventPublisher
+
     // ----------------- CancelScheduledEventHandlerTest -----------------
     @MockitoBean
     lateinit var awsSchedulerService: AwsSchedulerService
@@ -33,7 +38,7 @@ abstract class MailEventInvokeSituationTest : EmailModuleTestTemplate() {
 
     // ----------------- EmailSendEventListenerInvokeSituation -----------------
     @MockitoBean
-    lateinit var nonVariablesMailService: NonVariablesMailService
+    lateinit var nonVariablesMailServiceImpl: NonVariablesMailServiceImpl
 
     @MockitoBean
     lateinit var emailSentEventHandler: EmailSentEventHandler

--- a/src/test/kotlin/com/manage/crm/email/application/BrowseEmailNotificationSchedulesUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/BrowseEmailNotificationSchedulesUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.manage.crm.email.application
 import com.manage.crm.email.application.dto.BrowseEmailNotificationSchedulesUseCaseOut
 import com.manage.crm.email.application.dto.EmailNotificationScheduleDto
 import com.manage.crm.email.application.dto.ScheduleTaskView
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServiceImpl
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -13,7 +13,7 @@ import java.time.LocalDateTime
 import kotlin.random.Random
 
 class BrowseEmailNotificationSchedulesUseCaseTest : BehaviorSpec({
-    lateinit var scheduleTaskService: ScheduleTaskService
+    lateinit var scheduleTaskService: ScheduleTaskServiceImpl
     lateinit var useCase: BrowseEmailNotificationSchedulesUseCase
 
     beforeContainer {

--- a/src/test/kotlin/com/manage/crm/email/application/CancelNotificationEmailUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/CancelNotificationEmailUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.manage.crm.email.application
 
 import com.manage.crm.email.application.dto.CancelNotificationEmailUseCaseIn
 import com.manage.crm.email.application.dto.CancelNotificationEmailUseCaseOut
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.vo.EventId
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -11,7 +11,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 
 class CancelNotificationEmailUseCaseTest : BehaviorSpec({
-    lateinit var scheduleTaskService: ScheduleTaskService
+    lateinit var scheduleTaskService: ScheduleTaskServicePostEventProcessor
     lateinit var cancelNotificationEmailUseCase: CancelNotificationEmailUseCase
 
     beforeContainer {

--- a/src/test/kotlin/com/manage/crm/email/application/DeleteTemplateUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/DeleteTemplateUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.manage.crm.email.application.dto.DeleteTemplateUseCaseIn
 import com.manage.crm.email.application.dto.DeleteTemplateUseCaseOut
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.ScheduledEvent
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
 import com.manage.crm.email.domain.repository.ScheduledEventRepository
@@ -21,7 +21,7 @@ import java.time.LocalDateTime
 class DeleteTemplateUseCaseTest : BehaviorSpec({
     lateinit var emailTemplateRepository: EmailTemplateRepository
     lateinit var scheduledEventRepository: ScheduledEventRepository
-    lateinit var scheduleTaskService: ScheduleTaskService
+    lateinit var scheduleTaskService: ScheduleTaskServicePostEventProcessor
     lateinit var deleteTemplateUseCase: DeleteTemplateUseCase
 
     beforeContainer {

--- a/src/test/kotlin/com/manage/crm/email/application/PostEmailNotificationSchedulesUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/PostEmailNotificationSchedulesUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.manage.crm.email.application
 
 import com.manage.crm.email.application.dto.NotificationEmailSendTimeOutEventInput
 import com.manage.crm.email.application.dto.PostEmailNotificationSchedulesUseCaseIn
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.vo.EventId
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -12,7 +12,7 @@ import io.mockk.mockk
 import java.time.LocalDateTime
 
 class PostEmailNotificationSchedulesUseCaseTest : BehaviorSpec({
-    lateinit var scheduleTaskService: ScheduleTaskService
+    lateinit var scheduleTaskService: ScheduleTaskServicePostEventProcessor
     lateinit var useCase: PostEmailNotificationSchedulesUseCase
     beforeContainer {
         scheduleTaskService = mockk()

--- a/src/test/kotlin/com/manage/crm/email/application/SendNotificationEmailUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/SendNotificationEmailUseCaseTest.kt
@@ -1,13 +1,15 @@
 package com.manage.crm.email.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.manage.crm.email.application.dto.SendEmailDto
+import com.manage.crm.email.application.dto.SendEmailInDto
+import com.manage.crm.email.application.dto.SendEmailOutDto
 import com.manage.crm.email.application.dto.SendNotificationEmailUseCaseIn
-import com.manage.crm.email.application.service.NonVariablesMailService
+import com.manage.crm.email.application.service.NonVariablesMailServicePostEventProcessor
 import com.manage.crm.email.domain.EmailTemplate
 import com.manage.crm.email.domain.EmailTemplateHistory
 import com.manage.crm.email.domain.repository.EmailTemplateHistoryRepository
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
+import com.manage.crm.email.domain.vo.EmailProviderType
 import com.manage.crm.email.domain.vo.Variables
 import com.manage.crm.user.domain.User
 import com.manage.crm.user.domain.repository.UserRepository
@@ -16,14 +18,12 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 
 class SendNotificationEmailUseCaseTest : BehaviorSpec({
     lateinit var emailTemplateRepository: EmailTemplateRepository
     lateinit var emailTemplateHistoryRepository: EmailTemplateHistoryRepository
-    lateinit var nonVariablesEmailService: NonVariablesMailService
+    lateinit var nonVariablesEmailService: NonVariablesMailServicePostEventProcessor
     lateinit var userRepository: UserRepository
     lateinit var useCase: SendNotificationEmailUseCase
 
@@ -77,7 +77,15 @@ class SendNotificationEmailUseCaseTest : BehaviorSpec({
 
             coEvery { userRepository.findAllByIdIn(useCaseIn.userIds) } answers { userSubs(useCaseIn.userIds.size) }
 
-            coEvery { nonVariablesEmailService.send(any(SendEmailDto::class)) } just runs
+            coEvery { nonVariablesEmailService.send(any(SendEmailInDto::class)) } answers {
+                SendEmailOutDto(
+                    userId = 1L,
+                    emailBody = "emailBody",
+                    messageId = "messageId",
+                    destination = "destination",
+                    provider = EmailProviderType.JAVA
+                )
+            }
 
             val result = useCase.execute(useCaseIn)
             then("should return SendNotificationEmailUseCaseOut") {
@@ -93,7 +101,7 @@ class SendNotificationEmailUseCaseTest : BehaviorSpec({
             }
 
             then("send notification email") {
-                coVerify(exactly = 2) { nonVariablesEmailService.send(any(SendEmailDto::class)) }
+                coVerify(exactly = 2) { nonVariablesEmailService.send(any(SendEmailInDto::class)) }
             }
         }
 
@@ -117,7 +125,15 @@ class SendNotificationEmailUseCaseTest : BehaviorSpec({
 
             coEvery { userRepository.findAllByIdIn(useCaseIn.userIds) } answers { userSubs(useCaseIn.userIds.size) }
 
-            coEvery { nonVariablesEmailService.send(any(SendEmailDto::class)) } just runs
+            coEvery { nonVariablesEmailService.send(any(SendEmailInDto::class)) } answers {
+                SendEmailOutDto(
+                    userId = 1L,
+                    emailBody = "emailBody",
+                    messageId = "messageId",
+                    destination = "destination",
+                    provider = EmailProviderType.JAVA
+                )
+            }
 
             then("should return SendNotificationEmailUseCaseOut") {
                 val result = useCase.execute(useCaseIn)
@@ -133,7 +149,7 @@ class SendNotificationEmailUseCaseTest : BehaviorSpec({
             }
 
             then("send notification email") {
-                coVerify(exactly = 2) { nonVariablesEmailService.send(any(SendEmailDto::class)) }
+                coVerify(exactly = 2) { nonVariablesEmailService.send(any(SendEmailInDto::class)) }
             }
         }
 
@@ -158,7 +174,15 @@ class SendNotificationEmailUseCaseTest : BehaviorSpec({
             val key = "email"
             coEvery { userRepository.findAllExistByUserAttributesKey(key) } answers { userSubs(useCaseIn.userIds.size) }
 
-            coEvery { nonVariablesEmailService.send(any(SendEmailDto::class)) } just runs
+            coEvery { nonVariablesEmailService.send(any(SendEmailInDto::class)) } answers {
+                SendEmailOutDto(
+                    userId = 1L,
+                    emailBody = "emailBody",
+                    messageId = "messageId",
+                    destination = "destination",
+                    provider = EmailProviderType.JAVA
+                )
+            }
 
             then("should return SendNotificationEmailUseCaseOut") {
                 val result = useCase.execute(useCaseIn)
@@ -174,7 +198,7 @@ class SendNotificationEmailUseCaseTest : BehaviorSpec({
             }
 
             then("send notification email") {
-                coVerify(exactly = 0) { nonVariablesEmailService.send(any(SendEmailDto::class)) }
+                coVerify(exactly = 0) { nonVariablesEmailService.send(any(SendEmailInDto::class)) }
             }
         }
     }

--- a/src/test/kotlin/com/manage/crm/email/event/schedule/handler/ScheduledEventListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/schedule/handler/ScheduledEventListenerTest.kt
@@ -8,9 +8,7 @@ import com.manage.crm.infrastructure.scheduler.ScheduleName
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.*
 import org.mockito.kotlin.doNothing
 import org.springframework.modulith.test.Scenario
 
@@ -25,22 +23,18 @@ class ScheduledEventListenerTest(
             doNothing().`when`(awsSchedulerService).deleteSchedule(scheduleName)
 
             // when
-            run {
-                scheduleTaskService.cancel(scheduleName.value)
+            scheduleTaskService.cancel(scheduleName.value)
 
-                val event = CancelScheduledEvent(EventId(scheduleName.value))
-                `when`(cancelScheduledEventHandler.handle(event)).thenReturn(Unit)
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(CancelScheduledEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            runBlocking {
-                                verify(cancelScheduledEventHandler, times(1)).handle(event)
-                            }
-                        }
+            val event = CancelScheduledEvent(EventId(scheduleName.value))
+            `when`(cancelScheduledEventHandler.handle(event)).thenReturn(Unit)
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(CancelScheduledEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(cancelScheduledEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 }

--- a/src/test/kotlin/com/manage/crm/email/event/schedule/handler/ScheduledEventListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/schedule/handler/ScheduledEventListenerTest.kt
@@ -1,19 +1,20 @@
 package com.manage.crm.email.event.schedule.handler
 
 import com.manage.crm.email.MailEventInvokeSituationTest
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.vo.EventId
 import com.manage.crm.email.event.schedule.CancelScheduledEvent
 import com.manage.crm.infrastructure.scheduler.ScheduleName
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mockingDetails
+import org.mockito.Mockito.`when`
 import org.mockito.kotlin.doNothing
 import org.springframework.modulith.test.Scenario
+import kotlin.test.assertEquals
 
 class ScheduledEventListenerTest(
-    private val scheduleTaskService: ScheduleTaskService
+    private val scheduleTaskService: ScheduleTaskServicePostEventProcessor
 ) : MailEventInvokeSituationTest() {
     @Test
     fun `schedule task service cancel method is called`(scenario: Scenario) {
@@ -22,18 +23,23 @@ class ScheduledEventListenerTest(
             val scheduleName = ScheduleName(EventId().value)
             doNothing().`when`(awsSchedulerService).deleteSchedule(scheduleName)
 
+            val event = CancelScheduledEvent(EventId(scheduleName.value))
+            doNothing().`when`(emailEventPublisher).publishEvent(event)
+
             // when
             scheduleTaskService.cancel(scheduleName.value)
 
-            val event = CancelScheduledEvent(EventId(scheduleName.value))
             `when`(cancelScheduledEventHandler.handle(event)).thenReturn(Unit)
+
             // then
+            val expectedInvocationTime = 1
             scenario.publish(event)
-                .andWaitForEventOfType(CancelScheduledEvent::class.java)
-                .toArriveAndAssert { _, _ ->
-                    runBlocking {
-                        verify(cancelScheduledEventHandler, times(1)).handle(event)
-                    }
+                .andWaitForStateChange(
+                    { mockingDetails(cancelScheduledEventHandler).invocations.size },
+                    { mockingDetails(cancelScheduledEventHandler).invocations.size == expectedInvocationTime }
+                )
+                .andVerify { invocationTime ->
+                    assertEquals(invocationTime, expectedInvocationTime)
                 }
         }
     }

--- a/src/test/kotlin/com/manage/crm/email/event/send/EmailSendEventListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/send/EmailSendEventListenerTest.kt
@@ -12,15 +12,17 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.mockito.Mockito.doNothing
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.*
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.modulith.test.Scenario
 import java.time.ZonedDateTime
 
-fun getMessage(status: SentEmailStatus, email: String, timeStamp: ZonedDateTime, messageId: String): String {
+fun getMessage(
+    status: SentEmailStatus,
+    email: String,
+    timeStamp: ZonedDateTime,
+    messageId: String
+): String {
     return """
                     {
                         "Type" : "Notification",
@@ -61,29 +63,25 @@ class EmailSendEventListenerTest(
             `when`(nonVariablesMailService.send(sendEmailDto.emailArgs)).thenReturn("messageId")
 
             // when
-            run {
-                nonVariablesMailService.send(sendEmailDto)
+            nonVariablesMailService.send(sendEmailDto)
 
-                val event = EmailSentEvent(
-                    userId = 1,
-                    emailBody = "body",
-                    messageId = "messageId",
-                    destination = "example@example.com",
-                    provider = EmailProviderType.AWS
-                )
-                `when`(emailSentEventHandler.handle(event)).thenReturn(Unit)
+            val event = EmailSentEvent(
+                userId = 1,
+                emailBody = "body",
+                messageId = "messageId",
+                destination = "example@example.com",
+                provider = EmailProviderType.AWS
+            )
+            `when`(emailSentEventHandler.handle(event)).thenReturn(Unit)
 
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(EmailSentEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            runBlocking {
-                                verify(emailSentEventHandler, times(1)).handle(event)
-                            }
-                        }
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(EmailSentEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(emailSentEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 
@@ -100,27 +98,23 @@ class EmailSendEventListenerTest(
             doNothing().`when`(acknowledgement).acknowledge()
 
             // when
-            run {
-                sesMessageReverseRelay.onMessage(message, acknowledgement)
+            sesMessageReverseRelay.onMessage(message, acknowledgement)
 
-                val event = EmailOpenEvent(
-                    messageId = messageId,
-                    destination = email,
-                    timestamp = timeStamp,
-                    provider = EmailProviderType.AWS
-                )
+            val event = EmailOpenEvent(
+                messageId = messageId,
+                destination = email,
+                timestamp = timeStamp,
+                provider = EmailProviderType.AWS
+            )
 
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(EmailOpenEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            runBlocking {
-                                verify(emailOpenEventHandler, times(1)).handle(event)
-                            }
-                        }
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(EmailOpenEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(emailOpenEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 
@@ -137,27 +131,23 @@ class EmailSendEventListenerTest(
             doNothing().`when`(acknowledgement).acknowledge()
 
             // when
-            run {
-                sesMessageReverseRelay.onMessage(message, acknowledgement)
+            sesMessageReverseRelay.onMessage(message, acknowledgement)
 
-                val event = EmailDeliveryEvent(
-                    messageId = messageId,
-                    destination = email,
-                    timestamp = timeStamp,
-                    provider = EmailProviderType.AWS
-                )
+            val event = EmailDeliveryEvent(
+                messageId = messageId,
+                destination = email,
+                timestamp = timeStamp,
+                provider = EmailProviderType.AWS
+            )
 
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(EmailDeliveryEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            runBlocking {
-                                verify(emailDeliveryEventHandler, times(1)).handle(event)
-                            }
-                        }
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(EmailDeliveryEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(emailDeliveryEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 
@@ -174,27 +164,23 @@ class EmailSendEventListenerTest(
             doNothing().`when`(acknowledgement).acknowledge()
 
             // when
-            run {
-                sesMessageReverseRelay.onMessage(message, acknowledgement)
+            sesMessageReverseRelay.onMessage(message, acknowledgement)
 
-                val event = EmailDeliveryDelayEvent(
-                    messageId = messageId,
-                    destination = email,
-                    timestamp = timeStamp,
-                    provider = EmailProviderType.AWS
-                )
+            val event = EmailDeliveryDelayEvent(
+                messageId = messageId,
+                destination = email,
+                timestamp = timeStamp,
+                provider = EmailProviderType.AWS
+            )
 
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(EmailDeliveryDelayEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            runBlocking {
-                                verify(emailDeliveryDelayEventHandler, times(1)).handle(event)
-                            }
-                        }
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(EmailDeliveryDelayEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(emailDeliveryDelayEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 
@@ -211,26 +197,22 @@ class EmailSendEventListenerTest(
             doNothing().`when`(acknowledgement).acknowledge()
 
             // when
-            run {
-                sesMessageReverseRelay.onMessage(message, acknowledgement)
+            sesMessageReverseRelay.onMessage(message, acknowledgement)
 
-                val event = EmailClickEvent(
-                    messageId = messageId,
-                    destination = email,
-                    timestamp = timeStamp,
-                    provider = EmailProviderType.AWS
-                )
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(EmailClickEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            runBlocking {
-                                verify(emailClickEventHandler, times(1)).handle(event)
-                            }
-                        }
+            val event = EmailClickEvent(
+                messageId = messageId,
+                destination = email,
+                timestamp = timeStamp,
+                provider = EmailProviderType.AWS
+            )
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(EmailClickEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(emailClickEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 }

--- a/src/test/kotlin/com/manage/crm/email/event/send/notification/NotificationEmailSendTimeOutEventListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/send/notification/NotificationEmailSendTimeOutEventListenerTest.kt
@@ -2,29 +2,31 @@ package com.manage.crm.email.event.send.notification
 
 import com.manage.crm.email.MailEventInvokeSituationTest
 import com.manage.crm.email.application.dto.NotificationEmailSendTimeOutEventInput
-import com.manage.crm.email.application.service.ScheduleTaskService
+import com.manage.crm.email.application.service.ScheduleTaskServicePostEventProcessor
 import com.manage.crm.email.domain.vo.EventId
 import com.manage.crm.email.event.relay.aws.ScheduledEventReverseRelay
 import com.manage.crm.email.event.relay.aws.mapper.ScheduledEventMessageMapper
+import com.manage.crm.email.support.EmailEventPublisher
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.*
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.modulith.test.Scenario
 import software.amazon.awssdk.services.scheduler.model.CreateScheduleResponse
 import java.time.LocalDateTime
+import kotlin.test.assertEquals
 
 class NotificationEmailSendTimeOutEventListenerTest(
-    private val scheduleTaskService: ScheduleTaskService,
-    private val eventPublisher: ApplicationEventPublisher,
+    private val scheduleTaskService: ScheduleTaskServicePostEventProcessor,
     scheduledEventMessageMapper: ScheduledEventMessageMapper
 ) : MailEventInvokeSituationTest() {
 
+    private val scheduledEventReverseRelayEmailEventPublisher = mock(EmailEventPublisher::class.java)
     private var scheduledEventReverseRelay =
-        ScheduledEventReverseRelay(eventPublisher, scheduledEventMessageMapper)
+        ScheduledEventReverseRelay(
+            scheduledEventReverseRelayEmailEventPublisher,
+            scheduledEventMessageMapper
+        )
 
     @Test
     fun `schedule task service new schedule method is called`(scenario: Scenario) {
@@ -46,9 +48,6 @@ class NotificationEmailSendTimeOutEventListenerTest(
                 )
             ).thenReturn(CreateScheduleResponse.builder().scheduleArn("arn").build())
 
-            // when
-            scheduleTaskService.newSchedule(input)
-
             val event = NotificationEmailSendTimeOutEvent(
                 eventId = EventId("1"),
                 templateId = 1,
@@ -56,17 +55,22 @@ class NotificationEmailSendTimeOutEventListenerTest(
                 userIds = listOf(1L),
                 expiredTime = expiredTime
             )
+            doNothing().`when`(emailEventPublisher).publishEvent(event)
+
+            // when
+            scheduleTaskService.newSchedule(input)
+
             `when`(notificationEmailSendTimeOutEventHandler.handle(event)).thenReturn(Unit)
 
             // then
+            val expectedInvocationTime = 1
             scenario.publish(event)
-                .andWaitForEventOfType(NotificationEmailSendTimeOutEvent::class.java)
-                .toArriveAndAssert { _, _ ->
-                    runBlocking {
-                        verify(notificationEmailSendTimeOutEventHandler, times(1)).handle(
-                            event
-                        )
-                    }
+                .andWaitForStateChange(
+                    { mockingDetails(notificationEmailSendTimeOutEventHandler).invocations.size },
+                    { mockingDetails(notificationEmailSendTimeOutEventHandler).invocations.size == expectedInvocationTime }
+                )
+                .andVerify { invocationTime ->
+                    assertEquals(invocationTime, expectedInvocationTime)
                 }
         }
     }
@@ -83,25 +87,31 @@ class NotificationEmailSendTimeOutEventListenerTest(
                         "eventId": "1"
                     }
             """.trimIndent()
-            val acknowledgement = Mockito.mock(Acknowledgement::class.java)
+            val acknowledgement = mock(Acknowledgement::class.java)
             doNothing().`when`(acknowledgement).acknowledge()
 
-            // when
-            scheduledEventReverseRelay.onMessage(message, acknowledgement)
             val event = NotificationEmailSendTimeOutInvokeEvent(
                 timeOutEventId = EventId("1"),
                 templateId = 1,
                 templateVersion = 1.0f,
                 userIds = listOf(1L)
             )
+            doNothing().`when`(scheduledEventReverseRelayEmailEventPublisher).publishEvent(event)
+
+            // when
+            scheduledEventReverseRelay.onMessage(message, acknowledgement)
+
+            `when`(notificationEmailSendTimeOutInvokeEventHandler.handle(event)).thenReturn(Unit)
 
             // then
+            val expectedInvocationTime = 1
             scenario.publish(event)
-                .andWaitForEventOfType(NotificationEmailSendTimeOutInvokeEvent::class.java)
-                .toArriveAndAssert { _, _ ->
-                    runBlocking {
-                        verify(notificationEmailSendTimeOutInvokeEventHandler, times(1)).handle(event)
-                    }
+                .andWaitForStateChange(
+                    { mockingDetails(notificationEmailSendTimeOutInvokeEventHandler).invocations.size },
+                    { mockingDetails(notificationEmailSendTimeOutInvokeEventHandler).invocations.size == expectedInvocationTime }
+                )
+                .andVerify { invocationTime ->
+                    assertEquals(invocationTime, expectedInvocationTime)
                 }
         }
     }

--- a/src/test/kotlin/com/manage/crm/email/event/template/EventTemplateTransactionListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/template/EventTemplateTransactionListenerTest.kt
@@ -3,11 +3,12 @@ package com.manage.crm.email.event.template
 import com.manage.crm.email.MailEventInvokeSituationTest
 import com.manage.crm.email.domain.EmailTemplate
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mockingDetails
+import org.mockito.Mockito.`when`
 import org.springframework.modulith.test.Scenario
+import kotlin.test.assertEquals
 
 class EventTemplateTransactionListenerTest(
     val emailTemplateRepository: EmailTemplateRepository
@@ -35,12 +36,14 @@ class EventTemplateTransactionListenerTest(
             `when`(postEmailTemplateEventHandler.handle(event)).thenReturn(Unit)
 
             // then
+            val expectedInvocationTime = 1
             scenario.publish(event)
-                .andWaitForEventOfType(PostEmailTemplateEvent::class.java)
-                .toArriveAndAssert { _, _ ->
-                    runBlocking {
-                        verify(postEmailTemplateEventHandler, times(1)).handle(event)
-                    }
+                .andWaitForStateChange(
+                    { mockingDetails(postEmailTemplateEventHandler).invocations.size },
+                    { mockingDetails(postEmailTemplateEventHandler).invocations.size == expectedInvocationTime }
+                )
+                .andVerify { invocationTime ->
+                    assertEquals(invocationTime, expectedInvocationTime)
                 }
         }
     }

--- a/src/test/kotlin/com/manage/crm/email/event/template/EventTemplateTransactionListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/template/EventTemplateTransactionListenerTest.kt
@@ -6,9 +6,7 @@ import com.manage.crm.email.domain.repository.EmailTemplateRepository
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.*
 import org.springframework.modulith.test.Scenario
 
 class EventTemplateTransactionListenerTest(
@@ -27,28 +25,23 @@ class EventTemplateTransactionListenerTest(
             )
             emailTemplateRepository.save(emailTemplate) // save email template
             // when
-            run {
-                emailTemplate.modify()
-                    .modifySubject("newSubject")
-                    .modifyBody("newBody", emptyList())
-                    .done()
-                emailTemplateRepository.save(emailTemplate) // modify email template
+            emailTemplate.modify()
+                .modifySubject("newSubject")
+                .modifyBody("newBody", emptyList())
+                .done()
+            emailTemplateRepository.save(emailTemplate) // modify email template
 
-                val event = emailTemplate.domainEvents.first() as PostEmailTemplateEvent
-                `when`(postEmailTemplateEventHandler.handle(event)).thenReturn(Unit)
+            val event = emailTemplate.domainEvents.first() as PostEmailTemplateEvent
+            `when`(postEmailTemplateEventHandler.handle(event)).thenReturn(Unit)
 
-                // then
-                run {
-                    scenario.publish(event)
-                        .andWaitForEventOfType(PostEmailTemplateEvent::class.java)
-                        .toArriveAndAssert { _, _ ->
-                            // then
-                            runBlocking {
-                                verify(postEmailTemplateEventHandler, times(1)).handle(event)
-                            }
-                        }
+            // then
+            scenario.publish(event)
+                .andWaitForEventOfType(PostEmailTemplateEvent::class.java)
+                .toArriveAndAssert { _, _ ->
+                    runBlocking {
+                        verify(postEmailTemplateEventHandler, times(1)).handle(event)
+                    }
                 }
-            }
         }
     }
 }


### PR DESCRIPTION
- service 클래스 구현안에서 applicationEventPublisher를 postEventProcessor로 분리
- scenario의 andWaitForEventOfType 검증을 andWaitForStateChange를 활용하는 방법으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 이메일 전송 및 알림 이벤트 후처리 기능이 추가되어 서비스의 반응성이 개선되었습니다.
- **리팩토링**
  - 예약 관리와 이메일 전송 관련 서비스가 인터페이스 기반으로 전환되어 유지보수성과 확장성이 향상되었습니다.
- **테스트**
  - 전반적인 테스트 코드가 새 구조에 맞게 업데이트되어 시스템 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->