### PR TITLE
[Feat/#13] 변수의 기본 값을 포함 템플릿 저장

### DIFF
--- a/src/main/kotlin/com/manage/crm/email/application/BrowseTemplateUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/BrowseTemplateUseCase.kt
@@ -49,7 +49,7 @@ class BrowseTemplateUseCase(
                             templateName = template.templateName!!,
                             subject = template.subject!!,
                             body = template.body!!,
-                            variables = template.variables.value,
+                            variables = template.variables.getVariables(),
                             version = template.version,
                             createdAt = template.createdAt.toString()
                         ),
@@ -60,7 +60,7 @@ class BrowseTemplateUseCase(
                                 templateId = history.templateId!!,
                                 subject = history.subject!!,
                                 body = history.body!!,
-                                variables = history.variables.value,
+                                variables = history.variables.getVariables(),
                                 version = history.version,
                                 createdAt = history.createdAt.toString()
                             )

--- a/src/main/kotlin/com/manage/crm/email/application/PostTemplateUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/PostTemplateUseCase.kt
@@ -31,15 +31,15 @@ class PostTemplateUseCase(
         val version: Float? = useCaseIn.version
         val body = htmlService.prettyPrintHtml(useCaseIn.body)
         val variables = run {
-            val bodyVariables: List<String> = htmlService.extractVariables(body).sorted()
+            val bodyVariables = htmlService.extractVariables(body).sorted().let { Variables(it) }
             val variables = useCaseIn.variables
                 .filterNot { it.isBlank() }
                 .filterNot { it.isEmpty() }
                 .sorted()
                 .let { Variables(it) }
 
-            if (bodyVariables != variables.getVariables(false)) {
-                throw IllegalArgumentException("Variables do not match: \n$bodyVariables != $variables")
+            if (bodyVariables.getVariables(false) != variables.getVariables(false)) {
+                throw IllegalArgumentException("Variables do not match: \n${bodyVariables.getVariables(false)} != ${variables.getVariables(false)}")
             }
             return@run variables
         }

--- a/src/main/kotlin/com/manage/crm/email/application/PostTemplateUseCase.kt
+++ b/src/main/kotlin/com/manage/crm/email/application/PostTemplateUseCase.kt
@@ -7,6 +7,7 @@ import com.manage.crm.email.domain.EmailTemplate
 import com.manage.crm.email.domain.EmailTemplateHistory
 import com.manage.crm.email.domain.repository.EmailTemplateHistoryRepository
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
+import com.manage.crm.email.domain.vo.Variables
 import com.manage.crm.support.out
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -35,7 +36,9 @@ class PostTemplateUseCase(
                 .filterNot { it.isBlank() }
                 .filterNot { it.isEmpty() }
                 .sorted()
-            if (bodyVariables != variables) {
+                .let { Variables(it) }
+
+            if (bodyVariables != variables.getVariables(false)) {
                 throw IllegalArgumentException("Variables do not match: \n$bodyVariables != $variables")
             }
             return@run variables

--- a/src/main/kotlin/com/manage/crm/email/controller/request/PostTemplateRequest.kt
+++ b/src/main/kotlin/com/manage/crm/email/controller/request/PostTemplateRequest.kt
@@ -1,10 +1,13 @@
 package com.manage.crm.email.controller.request
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class PostTemplateRequest(
     val id: Long? = null,
     val templateName: String,
     val subject: String? = null,
     val version: Float? = null,
     val body: String,
+    @Schema(description = "변수 리스트", example = "[\"name:default\", \"email\"]")
     val variables: List<String>? = emptyList()
 )

--- a/src/main/kotlin/com/manage/crm/email/domain/EmailTemplate.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/EmailTemplate.kt
@@ -30,12 +30,12 @@ class EmailTemplate(
     var domainEvents: MutableList<PostEmailTemplateEvent> = mutableListOf()
 
     companion object {
-        fun new(templateName: String, subject: String, body: String, variables: List<String>): EmailTemplate {
+        fun new(templateName: String, subject: String, body: String, variables: Variables): EmailTemplate {
             return EmailTemplate(
                 templateName = templateName,
                 subject = subject,
                 body = body,
-                variables = Variables(variables)
+                variables = variables
             )
         }
     }
@@ -74,10 +74,10 @@ class EmailTemplate(
 
         fun modifyBody(
             body: String,
-            variables: List<String>
+            variables: Variables
         ): EmailTemplateModifyBuilder {
             template.body = body
-            template.variables = Variables(variables)
+            template.variables = variables
             return this
         }
 

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -29,7 +29,7 @@ data class Variables(
                 if (withDefault) {
                     it
                 } else {
-                    it.substringAfter(":")
+                    it.substringBefore(":")
                 }
             }
     }

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -8,7 +8,7 @@ private fun String.extractKey(delimiter: String): String {
     return this.substringBefore(delimiter)
 }
 
-const val DELIMITER = ":"
+private const val DELIMITER = ":"
 
 data class Variables(
     val value: List<String> = emptyList()

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -33,8 +33,8 @@ data class Variables(
         }
     }
 
-    fun findVariable(key: String, withDefault: Boolean = true): String? {
-        return value.find { it.extractKey() == key }
+    fun findVariable(key: String, withDefault: Boolean = true, delimiter: String = DELIMITER): String? {
+        return value.find { it == key || it.startsWith("$key$delimiter") }
             ?.let {
                 if (withDefault) {
                     it

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -3,7 +3,7 @@ package com.manage.crm.email.domain.vo
 const val DELIMITER = ":"
 
 private fun String.containDefault(delimiter: String = DELIMITER): Boolean {
-    return this.contains(DELIMITER)
+    return this.contains(delimiter)
 }
 
 private fun String.extractKey(delimiter: String = DELIMITER): String {

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -1,5 +1,13 @@
 package com.manage.crm.email.domain.vo
 
+/**
+ * Variables의 value는 다음과 같은 형태로 저장된다.
+ * - "title:hello", "name"
+ *
+ * "title:hello"는 key와 default value로 구성되어 있다.
+ *
+ * containDefault에서는 key와 default value를 구분하기 위한 delimiter를 사용하여 default value가 있는지 확인한다.
+ */
 private fun String.containDefault(delimiter: String): Boolean {
     return this.contains(delimiter)
 }

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -2,8 +2,8 @@ package com.manage.crm.email.domain.vo
 
 const val DELIMITER = ":"
 
-private fun String.containDefault(): Boolean {
-    return this.contains(":")
+private fun String.containDefault(delimiter: String = DELIMITER): Boolean {
+    return this.contains(DELIMITER)
 }
 
 private fun String.extractKey(delimiter: String = DELIMITER): String {

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -1,11 +1,13 @@
 package com.manage.crm.email.domain.vo
 
-private fun String.isContainDefault(): Boolean {
+const val DELIMITER = ":"
+
+private fun String.containDefault(): Boolean {
     return this.contains(":")
 }
 
-private fun String.getKeyFromValue(): String {
-    return this.substringBefore(":")
+private fun String.extractKey(delimiter: String = DELIMITER): String {
+    return this.substringBefore(delimiter)
 }
 
 data class Variables(
@@ -22,8 +24,8 @@ data class Variables(
             value
         } else {
             value.map {
-                if (it.isContainDefault()) {
-                    it.getKeyFromValue()
+                if (it.containDefault()) {
+                    it.extractKey()
                 } else {
                     it
                 }
@@ -31,13 +33,13 @@ data class Variables(
         }
     }
 
-    fun getVariable(key: String, withDefault: Boolean = true): String? {
-        return value.find { it.getKeyFromValue() == key }
+    fun findVariable(key: String, withDefault: Boolean = true): String? {
+        return value.find { it.extractKey() == key }
             ?.let {
                 if (withDefault) {
                     it
                 } else {
-                    it.getKeyFromValue()
+                    it.extractKey()
                 }
             }
     }

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -19,13 +19,13 @@ data class Variables(
         return value.isEmpty()
     }
 
-    fun getVariables(withDefault: Boolean = true): List<String> {
+    fun getVariables(withDefault: Boolean = true, delimiter: String = DELIMITER): List<String> {
         return if (withDefault) {
             value
         } else {
             value.map {
-                if (it.containDefault()) {
-                    it.extractKey()
+                if (it.containDefault(delimiter)) {
+                    it.extractKey(delimiter)
                 } else {
                     it
                 }

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -1,5 +1,13 @@
 package com.manage.crm.email.domain.vo
 
+private fun String.isContainDefault(): Boolean {
+    return this.contains(":")
+}
+
+private fun String.getKeyFromValue(): String {
+    return this.substringBefore(":")
+}
+
 data class Variables(
     val value: List<String> = emptyList()
 ) {
@@ -14,8 +22,8 @@ data class Variables(
             value
         } else {
             value.map {
-                if (it.contains(":")) {
-                    it.substringBefore(":")
+                if (it.isContainDefault()) {
+                    it.getKeyFromValue()
                 } else {
                     it
                 }
@@ -24,12 +32,12 @@ data class Variables(
     }
 
     fun getVariable(key: String, withDefault: Boolean = true): String? {
-        return value.find { it.substringBefore(":") == key }
+        return value.find { it.getKeyFromValue() == key }
             ?.let {
                 if (withDefault) {
                     it
                 } else {
-                    it.substringBefore(":")
+                    it.getKeyFromValue()
                 }
             }
     }

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -1,14 +1,14 @@
 package com.manage.crm.email.domain.vo
 
-const val DELIMITER = ":"
-
-private fun String.containDefault(delimiter: String = DELIMITER): Boolean {
+private fun String.containDefault(delimiter: String): Boolean {
     return this.contains(delimiter)
 }
 
-private fun String.extractKey(delimiter: String = DELIMITER): String {
+private fun String.extractKey(delimiter: String): String {
     return this.substringBefore(delimiter)
 }
+
+const val DELIMITER = ":"
 
 data class Variables(
     val value: List<String> = emptyList()
@@ -39,7 +39,7 @@ data class Variables(
                 if (withDefault) {
                     it
                 } else {
-                    it.extractKey()
+                    it.extractKey(delimiter)
                 }
             }
     }

--- a/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
+++ b/src/main/kotlin/com/manage/crm/email/domain/vo/Variables.kt
@@ -4,4 +4,33 @@ data class Variables(
     val value: List<String> = emptyList()
 ) {
     constructor(vararg value: String) : this(value.toList())
+
+    fun isEmpty(): Boolean {
+        return value.isEmpty()
+    }
+
+    fun getVariables(withDefault: Boolean = true): List<String> {
+        return if (withDefault) {
+            value
+        } else {
+            value.map {
+                if (it.contains(":")) {
+                    it.substringBefore(":")
+                } else {
+                    it
+                }
+            }
+        }
+    }
+
+    fun getVariable(key: String, withDefault: Boolean = true): String? {
+        return value.find { it.substringBefore(":") == key }
+            ?.let {
+                if (withDefault) {
+                    it
+                } else {
+                    it.substringAfter(":")
+                }
+            }
+    }
 }

--- a/src/test/kotlin/com/manage/crm/email/application/PostTemplateUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/PostTemplateUseCaseTest.kt
@@ -7,6 +7,7 @@ import com.manage.crm.email.domain.EmailTemplate
 import com.manage.crm.email.domain.EmailTemplateHistory
 import com.manage.crm.email.domain.repository.EmailTemplateHistoryRepository
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
+import com.manage.crm.email.domain.vo.Variables
 import com.manage.crm.email.event.template.PostEmailTemplateEvent
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -64,7 +65,7 @@ class PostTemplateUseCaseTest : BehaviorSpec({
                 templateName = useCaseIn.templateName,
                 subject = useCaseIn.subject!!,
                 body = useCaseIn.body,
-                variables = useCaseIn.variables
+                variables = Variables(useCaseIn.variables)
             ).apply {
                 // set id after save
                 id = 1
@@ -137,7 +138,7 @@ class PostTemplateUseCaseTest : BehaviorSpec({
                 templateName = useCaseIn.templateName,
                 subject = "subject",
                 body = "body",
-                variables = emptyList()
+                variables = Variables(emptyList())
             ).apply {
                 id = useCaseIn.id
                 version = 1.0f
@@ -148,7 +149,7 @@ class PostTemplateUseCaseTest : BehaviorSpec({
                 templateName = useCaseIn.templateName,
                 subject = useCaseIn.subject!!,
                 body = useCaseIn.body,
-                variables = useCaseIn.variables
+                variables = Variables(useCaseIn.variables)
             ).apply {
                 id = useCaseIn.id
                 version = useCaseIn.version!!

--- a/src/test/kotlin/com/manage/crm/email/application/PostTemplateUseCaseTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/application/PostTemplateUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.manage.crm.email.domain.repository.EmailTemplateHistoryRepository
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
 import com.manage.crm.email.domain.vo.Variables
 import com.manage.crm.email.event.template.PostEmailTemplateEvent
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -184,6 +185,230 @@ class PostTemplateUseCaseTest : BehaviorSpec({
             }
 
             then("publish update template event") {
+                coVerify(exactly = 1) { applicationEventPublisher.publishEvent(any(PostEmailTemplateEvent::class)) }
+            }
+        }
+
+        `when`("create new template with variable") {
+            val useCaseIn = PostTemplateUseCaseIn(
+                id = null,
+                templateName = "templateName",
+                subject = "subject",
+                version = null,
+                body = "body with variable \${email}",
+                variables = listOf("email")
+            )
+
+            coEvery { htmlService.prettyPrintHtml(useCaseIn.body) } answers {
+                useCaseIn.body
+            }
+
+            coEvery { htmlService.extractVariables(useCaseIn.body) } answers {
+                useCaseIn.variables.map { it.substringBefore(":") }
+            }
+
+            coEvery { emailTemplateRepository.findByTemplateName(useCaseIn.templateName) } answers {
+                null
+            }
+
+            val newEmailTemplate = EmailTemplate.new(
+                templateName = useCaseIn.templateName,
+                subject = useCaseIn.subject!!,
+                body = useCaseIn.body,
+                variables = Variables(useCaseIn.variables)
+            ).apply {
+                // set id after save
+                id = 1
+            }
+            coEvery { emailTemplateRepository.save(any(EmailTemplate::class)) } answers { newEmailTemplate }
+
+            val emailTemplateHistory = EmailTemplateHistory(
+                templateId = newEmailTemplate.id!!,
+                subject = newEmailTemplate.subject,
+                body = newEmailTemplate.body,
+                variables = newEmailTemplate.variables,
+                version = newEmailTemplate.version
+            )
+            coEvery { emailTemplateHistoryRepository.save(any(EmailTemplateHistory::class)) } answers { emailTemplateHistory }
+
+            coEvery { applicationEventPublisher.publishEvent(any(PostEmailTemplateEvent::class)) } just runs
+
+            val result = useCase.execute(useCaseIn)
+            then("should return BrowseEmailNotificationSchedulesUseCaseOut") {
+                result shouldBe PostTemplateUseCaseOut(
+                    id = newEmailTemplate.id!!,
+                    templateName = newEmailTemplate.templateName!!,
+                    version = newEmailTemplate.version
+                )
+            }
+
+            then("pretty useCaseIn.body") {
+                coVerify(exactly = 1) { htmlService.prettyPrintHtml(useCaseIn.body) }
+            }
+
+            then("extract variables") {
+                coVerify(exactly = 1) { htmlService.extractVariables(useCaseIn.body) }
+            }
+
+            then("check if template exists") {
+                coVerify(exactly = 1) { emailTemplateRepository.findByTemplateName(useCaseIn.templateName) }
+            }
+
+            then("save new template") {
+                coVerify(exactly = 1) { emailTemplateRepository.save(any(EmailTemplate::class)) }
+            }
+
+            then("save new template history") {
+                coVerify(exactly = 1) { emailTemplateHistoryRepository.save(any(EmailTemplateHistory::class)) }
+            }
+
+            then("publish save template event") {
+                coVerify(exactly = 1) { applicationEventPublisher.publishEvent(any(PostEmailTemplateEvent::class)) }
+            }
+        }
+
+        `when`("create new template with invalid variable") {
+            val useCaseIn = PostTemplateUseCaseIn(
+                id = null,
+                templateName = "templateName",
+                subject = "subject",
+                version = null,
+                body = "body with variable \${email}",
+                variables = listOf("name")
+            )
+
+            coEvery { htmlService.prettyPrintHtml(useCaseIn.body) } answers {
+                useCaseIn.body
+            }
+
+            val bodyVariables = listOf("email")
+            coEvery { htmlService.extractVariables(useCaseIn.body) } answers {
+                bodyVariables
+            }
+
+            val exception = shouldThrow<IllegalArgumentException> { useCase.execute(useCaseIn) }
+
+            then("should throw IllegalArgumentException") {
+                exception.message shouldBe "Variables do not match: \n$bodyVariables != ${useCaseIn.variables}"
+            }
+
+            then("pretty useCaseIn.body") {
+                coVerify(exactly = 1) { htmlService.prettyPrintHtml(useCaseIn.body) }
+            }
+
+            then("extract variables") {
+                coVerify(exactly = 1) { htmlService.extractVariables(useCaseIn.body) }
+            }
+        }
+
+        `when`("create new template with invalid body to extract variables") {
+            val useCaseIn = PostTemplateUseCaseIn(
+                id = null,
+                templateName = "templateName",
+                subject = "subject",
+                version = null,
+                body = "body with variable \${{email}}",
+                variables = listOf("email")
+            )
+
+            coEvery { htmlService.prettyPrintHtml(useCaseIn.body) } answers {
+                useCaseIn.body
+            }
+
+            val invalidBodyVariables = listOf("{email}")
+            coEvery { htmlService.extractVariables(useCaseIn.body) } answers {
+                invalidBodyVariables
+            }
+
+            val exception = shouldThrow<IllegalArgumentException> { useCase.execute(useCaseIn) }
+
+            then("should throw IllegalArgumentException") {
+                exception.message shouldBe "Variables do not match: \n$invalidBodyVariables != ${useCaseIn.variables}"
+            }
+
+            then("pretty useCaseIn.body") {
+                coVerify(exactly = 1) { htmlService.prettyPrintHtml(useCaseIn.body) }
+            }
+
+            then("extract variables") {
+                coVerify(exactly = 1) { htmlService.extractVariables(useCaseIn.body) }
+            }
+        }
+
+        `when`("create new template with variable and default") {
+            val useCaseIn = PostTemplateUseCaseIn(
+                id = null,
+                templateName = "templateName",
+                subject = "subject",
+                version = null,
+                body = "body with variable \${email}",
+                variables = listOf("email:test@gmail.com")
+            )
+
+            coEvery { htmlService.prettyPrintHtml(useCaseIn.body) } answers {
+                useCaseIn.body
+            }
+
+            coEvery { htmlService.extractVariables(useCaseIn.body) } answers {
+                useCaseIn.variables.map { it.substringBefore(":") }
+            }
+
+            coEvery { emailTemplateRepository.findByTemplateName(useCaseIn.templateName) } answers {
+                null
+            }
+
+            val newEmailTemplate = EmailTemplate.new(
+                templateName = useCaseIn.templateName,
+                subject = useCaseIn.subject!!,
+                body = useCaseIn.body,
+                variables = Variables(useCaseIn.variables)
+            ).apply {
+                // set id after save
+                id = 1
+            }
+            coEvery { emailTemplateRepository.save(any(EmailTemplate::class)) } answers { newEmailTemplate }
+
+            val emailTemplateHistory = EmailTemplateHistory(
+                templateId = newEmailTemplate.id!!,
+                subject = newEmailTemplate.subject,
+                body = newEmailTemplate.body,
+                variables = newEmailTemplate.variables,
+                version = newEmailTemplate.version
+            )
+            coEvery { emailTemplateHistoryRepository.save(any(EmailTemplateHistory::class)) } answers { emailTemplateHistory }
+
+            coEvery { applicationEventPublisher.publishEvent(any(PostEmailTemplateEvent::class)) } just runs
+
+            val result = useCase.execute(useCaseIn)
+            then("should return BrowseEmailNotificationSchedulesUseCaseOut") {
+                result shouldBe PostTemplateUseCaseOut(
+                    id = newEmailTemplate.id!!,
+                    templateName = newEmailTemplate.templateName!!,
+                    version = newEmailTemplate.version
+                )
+            }
+
+            then("pretty useCaseIn.body") {
+                coVerify(exactly = 1) { htmlService.prettyPrintHtml(useCaseIn.body) }
+            }
+
+            then("extract variables") {
+                coVerify(exactly = 1) { htmlService.extractVariables(useCaseIn.body) }
+            }
+
+            then("check if template exists") {
+                coVerify(exactly = 1) { emailTemplateRepository.findByTemplateName(useCaseIn.templateName) }
+            }
+
+            then("save new template") {
+                coVerify(exactly = 1) { emailTemplateRepository.save(any(EmailTemplate::class)) }
+            }
+
+            then("save new template history") {
+                coVerify(exactly = 1) { emailTemplateHistoryRepository.save(any(EmailTemplateHistory::class)) }
+            }
+
+            then("publish save template event") {
                 coVerify(exactly = 1) { applicationEventPublisher.publishEvent(any(PostEmailTemplateEvent::class)) }
             }
         }

--- a/src/test/kotlin/com/manage/crm/email/domain/EmailTemplateTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/domain/EmailTemplateTest.kt
@@ -15,7 +15,7 @@ class EmailTemplateTest : FeatureSpec({
             val variables = Variables()
 
             // when
-            val emailTemplate = EmailTemplate.new(templateName, subject, body, variables.value)
+            val emailTemplate = EmailTemplate.new(templateName, subject, body, Variables(variables.value))
 
             // then
             emailTemplate.templateName shouldBe templateName
@@ -42,7 +42,7 @@ class EmailTemplateTest : FeatureSpec({
         scenario("modify email template subject") {
             // given
             val subject = "newSubject"
-            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", variables.value)
+            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", Variables(variables.value))
             emailTemplate.id = 1
 
             // when
@@ -57,12 +57,12 @@ class EmailTemplateTest : FeatureSpec({
         scenario("modify email template body with variables") {
             // given
             val body = "newBody"
-            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", variables.value)
+            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", Variables(variables.value))
             emailTemplate.id = 1
 
             // when
             val modifiedTemplate = emailTemplate.modify()
-                .modifyBody(body, variables.value)
+                .modifyBody(body, variables)
                 .done()
 
             // then
@@ -72,7 +72,7 @@ class EmailTemplateTest : FeatureSpec({
         scenario("modify email template version") {
             // given
             val version = 2.0f
-            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", variables.value)
+            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", Variables(variables.value))
             emailTemplate.id = 1
 
             // when
@@ -87,7 +87,7 @@ class EmailTemplateTest : FeatureSpec({
         scenario("modify email template version under current version") {
             // given
             val version = 0.9f
-            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", variables.value)
+            val emailTemplate = EmailTemplate.new("templateName", "subject", "body", Variables(variables.value))
             emailTemplate.id = 1
 
             // when

--- a/src/test/kotlin/com/manage/crm/email/domain/vo/VariablesTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/domain/vo/VariablesTest.kt
@@ -1,0 +1,65 @@
+package com.manage.crm.email.domain.vo
+
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+
+class VariablesTest : FeatureSpec({
+
+    feature(("Variables#isEmpty")) {
+        scenario("check if variables is empty") {
+            // given
+            val variables = Variables()
+
+            // then
+            variables.isEmpty() shouldBe true
+        }
+    }
+
+    feature("Variables#getVariables") {
+        scenario("get variables") {
+            // given
+            val variables = Variables("title:hello", "name")
+
+            // when
+            val result = variables.getVariables()
+
+            // then
+            result shouldBe listOf("title:hello", "name")
+        }
+
+        scenario("get variables without default") {
+            // given
+            val variables = Variables("title:hello", "name")
+
+            // when
+            val result = variables.getVariables(withDefault = false)
+
+            // then
+            result shouldBe listOf("title", "name")
+        }
+    }
+
+    feature("Variables#getVariable") {
+        scenario("get variable") {
+            // given
+            val variables = Variables("title:hello", "name")
+
+            // when
+            val result = variables.getVariable("title")
+
+            // then
+            result shouldBe "title:hello"
+        }
+
+        scenario("get variable without default") {
+            // given
+            val variables = Variables("title:hello", "name")
+
+            // when
+            val result = variables.getVariable("title", withDefault = false)
+
+            // then
+            result shouldBe "title"
+        }
+    }
+})

--- a/src/test/kotlin/com/manage/crm/email/domain/vo/VariablesTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/domain/vo/VariablesTest.kt
@@ -39,13 +39,13 @@ class VariablesTest : FeatureSpec({
         }
     }
 
-    feature("Variables#getVariable") {
+    feature("Variables#findVariable") {
         scenario("get variable") {
             // given
             val variables = Variables("title:hello", "name")
 
             // when
-            val result = variables.getVariable("title")
+            val result = variables.findVariable("title")
 
             // then
             result shouldBe "title:hello"
@@ -56,7 +56,7 @@ class VariablesTest : FeatureSpec({
             val variables = Variables("title:hello", "name")
 
             // when
-            val result = variables.getVariable("title", withDefault = false)
+            val result = variables.findVariable("title", withDefault = false)
 
             // then
             result shouldBe "title"

--- a/src/test/kotlin/com/manage/crm/email/event/template/EventTemplateTransactionListenerTest.kt
+++ b/src/test/kotlin/com/manage/crm/email/event/template/EventTemplateTransactionListenerTest.kt
@@ -3,6 +3,7 @@ package com.manage.crm.email.event.template
 import com.manage.crm.email.MailEventInvokeSituationTest
 import com.manage.crm.email.domain.EmailTemplate
 import com.manage.crm.email.domain.repository.EmailTemplateRepository
+import com.manage.crm.email.domain.vo.Variables
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mockingDetails
@@ -22,13 +23,13 @@ class EventTemplateTransactionListenerTest(
                 templateName = "templateName",
                 subject = "subject",
                 body = "body",
-                variables = emptyList()
+                variables = Variables(emptyList())
             )
             emailTemplateRepository.save(emailTemplate) // save email template
             // when
             emailTemplate.modify()
                 .modifySubject("newSubject")
-                .modifyBody("newBody", emptyList())
+                .modifyBody("newBody", Variables(emptyList()))
                 .done()
             emailTemplateRepository.save(emailTemplate) // modify email template
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이메일 템플릿 API에 선택적으로 변수 목록을 지정할 수 있는 기능이 추가되어 템플릿 생성 및 수정 시 커스터마이징이 강화되었습니다.
  - `Variables` 클래스를 도입하여 변수 목록의 처리 방식을 개선했습니다.
  - `PostTemplateRequest` 데이터 클래스에 `variables` 속성이 추가되었습니다.
  - `Variables` 클래스에 대한 단위 테스트가 추가되었습니다.

- **버그 수정**
  - 변수 비교 로직이 개선되어, 잘못된 변수 입력 시 예외 처리가 강화되었습니다.

- **리팩터링**
  - 템플릿 변수의 처리 및 비교 로직이 개선되어, 보다 안정적이고 일관된 동작을 제공합니다.
  - 템플릿 DTO 및 히스토리 DTO에서 변수 접근 방식을 변경하여 코드의 일관성을 높였습니다.
  - 이메일 템플릿의 `new` 및 `modifyBody` 메서드에서 변수 처리 방식을 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->