### PR TITLE
[Feat/#23] 이벤트를 하나로 모을 수 있는 캠페인 생성

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/event/application/PostCampaignUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/PostCampaignUseCase.kt
@@ -1,0 +1,50 @@
+package com.manage.crm.event.application
+
+import com.manage.crm.event.application.dto.PostCampaignPropertyDto
+import com.manage.crm.event.application.dto.PostCampaignUseCaseIn
+import com.manage.crm.event.application.dto.PostCampaignUseCaseOut
+import com.manage.crm.event.domain.Campaign
+import com.manage.crm.event.domain.repository.CampaignRepository
+import com.manage.crm.event.domain.vo.Properties
+import com.manage.crm.event.domain.vo.Property
+import com.manage.crm.support.out
+import org.springframework.stereotype.Service
+
+// TODO: check concurrency issues: existsCampaignsByName and save
+@Service
+class PostCampaignUseCase(
+    private val campaignRepository: CampaignRepository
+) {
+    suspend fun execute(useCaseIn: PostCampaignUseCaseIn): PostCampaignUseCaseOut {
+        val campaignName = useCaseIn.name
+        val properties = useCaseIn.properties
+
+        if (campaignRepository.existsCampaignsByName(campaignName)) {
+            throw IllegalArgumentException("Campaign already exists with name: $campaignName")
+        }
+
+        val savedCampaign = campaignRepository.save(
+            Campaign(
+                name = campaignName,
+                properties = Properties(
+                    properties.map { (key, value) ->
+                        Property(key = key, value = value)
+                    }
+                )
+            )
+        )
+
+        return out {
+            PostCampaignUseCaseOut(
+                id = savedCampaign.id!!,
+                name = savedCampaign.name!!,
+                properties = savedCampaign.properties!!.value.map {
+                    PostCampaignPropertyDto(
+                        key = it.key,
+                        value = it.value
+                    )
+                }.toList()
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/event/application/dto/PostCampaignUseCaseDto.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/dto/PostCampaignUseCaseDto.kt
@@ -1,0 +1,19 @@
+package com.manage.crm.event.application.dto
+
+data class PostCampaignUseCaseIn(
+    val name: String,
+    val properties: List<PostCampaignPropertyDto>
+)
+
+data class PostCampaignPropertyDto(
+    val key: String,
+    val value: String
+)
+
+data class PostCampaignUseCaseOut(
+    val id: Long,
+    val name: String,
+    val properties: List<PostCampaignPropertyDto>
+)
+
+class PostCampaignUseCaseDto

--- a/backend/src/main/kotlin/com/manage/crm/event/controller/EventController.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/controller/EventController.kt
@@ -1,8 +1,12 @@
 package com.manage.crm.event.controller
 
 import com.manage.crm.config.SwaggerTag
+import com.manage.crm.event.application.PostCampaignUseCase
 import com.manage.crm.event.application.PostEventUseCase
 import com.manage.crm.event.application.SearchEventsUseCase
+import com.manage.crm.event.application.dto.PostCampaignPropertyDto
+import com.manage.crm.event.application.dto.PostCampaignUseCaseIn
+import com.manage.crm.event.application.dto.PostCampaignUseCaseOut
 import com.manage.crm.event.application.dto.PostEventPropertyDto
 import com.manage.crm.event.application.dto.PostEventUseCaseIn
 import com.manage.crm.event.application.dto.PostEventUseCaseOut
@@ -10,6 +14,7 @@ import com.manage.crm.event.application.dto.PropertyAndOperationDto
 import com.manage.crm.event.application.dto.SearchEventPropertyDto
 import com.manage.crm.event.application.dto.SearchEventsUseCaseIn
 import com.manage.crm.event.application.dto.SearchEventsUseCaseOut
+import com.manage.crm.event.controller.request.PostCampaignRequest
 import com.manage.crm.event.controller.request.PostEventRequest
 import com.manage.crm.event.domain.JoinOperation
 import com.manage.crm.event.domain.Operation
@@ -33,7 +38,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(value = ["/api/v1/events"])
 class EventController(
     private val postEventUseCase: PostEventUseCase,
-    private val searchEventsUseCase: SearchEventsUseCase
+    private val searchEventsUseCase: SearchEventsUseCase,
+    private val postCampaignUseCase: PostCampaignUseCase
 ) {
 
     @PostMapping
@@ -98,6 +104,23 @@ class EventController(
                             joinOperation = JoinOperation.fromValue(it.split("&")[count - 1])
                         )
                     }.toList()
+                )
+            )
+            .let { ApiResponseGenerator.success(it, HttpStatus.OK) }
+    }
+
+    @PostMapping("/campaign")
+    suspend fun postCampaign(@RequestBody request: PostCampaignRequest): ApiResponse<ApiResponse.SuccessBody<PostCampaignUseCaseOut>> {
+        return postCampaignUseCase
+            .execute(
+                PostCampaignUseCaseIn(
+                    name = request.name,
+                    properties = request.properties.map {
+                        PostCampaignPropertyDto(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }
                 )
             )
             .let { ApiResponseGenerator.success(it, HttpStatus.OK) }

--- a/backend/src/main/kotlin/com/manage/crm/event/controller/EventController.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/controller/EventController.kt
@@ -59,7 +59,7 @@ class EventController(
                     }
                 )
             )
-            .let { ApiResponseGenerator.success(it, HttpStatus.OK) }
+            .let { ApiResponseGenerator.success(it, HttpStatus.CREATED) }
     }
 
     @Parameters(
@@ -123,6 +123,6 @@ class EventController(
                     }
                 )
             )
-            .let { ApiResponseGenerator.success(it, HttpStatus.OK) }
+            .let { ApiResponseGenerator.success(it, HttpStatus.CREATED) }
     }
 }

--- a/backend/src/main/kotlin/com/manage/crm/event/controller/request/PostCampaignRequest.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/controller/request/PostCampaignRequest.kt
@@ -1,0 +1,11 @@
+package com.manage.crm.event.controller.request
+
+data class PostCampaignRequest(
+    val name: String,
+    val properties: List<PostCampaignPropertyDto>
+)
+
+data class PostCampaignPropertyDto(
+    val key: String,
+    val value: String
+)

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
@@ -1,0 +1,19 @@
+package com.manage.crm.event.domain
+
+import com.manage.crm.event.domain.vo.Properties
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+
+@Table("campaigns")
+class Campaign(
+    @Id
+    var id: Long? = null,
+    @Column("name")
+    var name: String? = null,
+    @Column("properties")
+    var properties: Properties? = null,
+    @Column("created_at")
+    var createdAt: LocalDateTime? = null
+)

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/CampaignEvents.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/CampaignEvents.kt
@@ -1,0 +1,18 @@
+package com.manage.crm.event.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+
+@Table("campaign_events")
+class CampaignEvents(
+    @Id
+    var id: Long? = null,
+    @Column("campaign_id")
+    var campaignId: Long? = null,
+    @Column("event_id")
+    var eventId: Long? = null,
+    @Column("created_at")
+    var createdAt: LocalDateTime? = null
+)

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/repository/CampaignEventsRepository.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/repository/CampaignEventsRepository.kt
@@ -1,0 +1,6 @@
+package com.manage.crm.event.domain.repository
+
+import com.manage.crm.event.domain.CampaignEvents
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface CampaignEventsRepository : CoroutineCrudRepository<CampaignEvents, Long>

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/repository/CampaignRepository.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/repository/CampaignRepository.kt
@@ -1,0 +1,9 @@
+package com.manage.crm.event.domain.repository
+
+import com.manage.crm.event.domain.Campaign
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface CampaignRepository : CoroutineCrudRepository<Campaign, Long> {
+
+    suspend fun existsCampaignsByName(name: String): Boolean
+}

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
@@ -1,0 +1,105 @@
+package com.manage.crm.event.application
+
+import com.manage.crm.event.application.dto.PostCampaignPropertyDto
+import com.manage.crm.event.application.dto.PostCampaignUseCaseIn
+import com.manage.crm.event.domain.Campaign
+import com.manage.crm.event.domain.repository.CampaignRepository
+import com.manage.crm.event.domain.vo.Properties
+import com.manage.crm.event.domain.vo.Property
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.ints.exactly
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+
+class PostCampaignUseCaseTest : BehaviorSpec({
+    lateinit var campaignRepository: CampaignRepository
+    lateinit var postCampaignUseCase: PostCampaignUseCase
+
+    beforeContainer {
+        campaignRepository = mockk()
+        postCampaignUseCase = PostCampaignUseCase(campaignRepository)
+    }
+
+    given("PostCampaignUseCase") {
+        `when`("post campaign") {
+            val useCaseIn = PostCampaignUseCaseIn(
+                name = "campaign",
+                properties = listOf(
+                    PostCampaignPropertyDto(
+                        key = "key1",
+                        value = "value1"
+                    ),
+                    PostCampaignPropertyDto(
+                        key = "key2",
+                        value = "value2"
+                    )
+                )
+            )
+
+            coEvery { campaignRepository.existsCampaignsByName(useCaseIn.name) } returns false
+
+            val savedCampaign = Campaign(
+                name = useCaseIn.name,
+                properties = Properties(
+                    useCaseIn.properties.map {
+                        Property(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }
+                )
+            )
+            val savedCampaignId = 1L
+            coEvery { campaignRepository.save(any()) } answers {
+                savedCampaign.apply {
+                    id = savedCampaignId
+                }
+            }
+
+            val result = postCampaignUseCase.execute(useCaseIn)
+
+            then("should return PostCampaignUseCaseOut") {
+                result.id shouldBe savedCampaignId
+                result.name shouldBe useCaseIn.name
+                result.properties.size shouldBe useCaseIn.properties.size
+            }
+
+            then("check campaign name is exists") {
+                coVerify(exactly = 1) { campaignRepository.existsCampaignsByName(useCaseIn.name) }
+            }
+
+            then("save campaign") {
+                coVerify(exactly = 1) { campaignRepository.save(any()) }
+            }
+        }
+
+        `when`("post campaign with existing name") {
+            val useCaseIn = PostCampaignUseCaseIn(
+                name = "existing_campaign",
+                properties = listOf(
+                    PostCampaignPropertyDto(
+                        key = "key1",
+                        value = "value1"
+                    )
+                )
+            )
+
+            coEvery { campaignRepository.existsCampaignsByName(useCaseIn.name) } returns true
+
+            then("should throw exception") {
+                val exception = shouldThrow<IllegalArgumentException> {
+                    postCampaignUseCase.execute(useCaseIn)
+                }
+
+                exception.message shouldBe "Campaign already exists with name: ${useCaseIn.name}"
+            }
+
+            then("check campaign name is exists") {
+                coVerify(exactly = 1) { campaignRepository.existsCampaignsByName(useCaseIn.name) }
+            }
+        }
+    }
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 캠페인 생성 및 등록 기능이 추가되어, API를 통해 캠페인 이름과 관련 속성을 전송하면 신규 캠페인을 생성할 수 있습니다.
  - 이름 중복 검증이 적용되어, 이미 존재하는 캠페인 이름으로 인한 오류를 방지합니다.
  - 캠페인 및 관련 이벤트 데이터를 효과적으로 관리할 수 있도록 데이터 구조와 저장 기능이 개선되었습니다.

- **테스트**
  - 캠페인 생성 및 중복 검증 기능에 대한 자동화 테스트를 추가하여 기능의 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->