### PR TITLE
[Feat/#27] 이벤트(도메인) 등록시 캠페인 함께 등록할 수 있도록 추가 구현

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/event/application/PostEventUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/PostEventUseCase.kt
@@ -1,18 +1,40 @@
 package com.manage.crm.event.application
 
+import arrow.fx.coroutines.parZip
+import com.manage.crm.event.application.dto.PostEventPropertyDto
 import com.manage.crm.event.application.dto.PostEventUseCaseIn
 import com.manage.crm.event.application.dto.PostEventUseCaseOut
+import com.manage.crm.event.domain.Campaign
+import com.manage.crm.event.domain.CampaignEvents
 import com.manage.crm.event.domain.Event
+import com.manage.crm.event.domain.repository.CampaignEventsRepository
+import com.manage.crm.event.domain.repository.CampaignRepository
 import com.manage.crm.event.domain.repository.EventRepository
 import com.manage.crm.event.domain.vo.Properties
 import com.manage.crm.event.domain.vo.Property
 import com.manage.crm.support.out
 import com.manage.crm.user.domain.repository.UserRepository
+import kotlinx.coroutines.Dispatchers
 import org.springframework.stereotype.Service
+
+enum class SaveEventMessage(val message: String) {
+    EVENT_SAVE_SUCCESS("Event saved successfully"),
+    EVENT_SAVE_WITH_CAMPAIGN("Event saved with campaign"),
+    PROPERTIES_MISMATCH("Campaign properties and Event properties mismatch")
+}
+
+data class SavedEvent(
+    val id: Long,
+    val message: String
+) {
+    constructor(id: Long, message: SaveEventMessage) : this(id, message.message)
+}
 
 @Service
 class PostEventUseCase(
     private val eventRepository: EventRepository,
+    private val campaignRepository: CampaignRepository,
+    private val campaignEventsRepository: CampaignEventsRepository,
     private val userRepository: UserRepository
 ) {
 
@@ -20,11 +42,34 @@ class PostEventUseCase(
         val eventName = useCaseIn.name
         val externalId = useCaseIn.externalId
         val properties = useCaseIn.properties
+        val campaignName = useCaseIn.campaignName
 
         val userId = userRepository.findByExternalId(externalId)?.id
             ?: throw IllegalArgumentException("User not found by externalId: $externalId")
 
-        val savedEvent = eventRepository.save(
+        val savedEvent = parZip(
+            Dispatchers.IO,
+            { saveEvent(eventName, userId, properties) },
+            { findCampaign(campaignName) }
+        ) { event, campaign ->
+            campaign?.let {
+                if (!it.allMatchPropertyKeys(event.properties!!.getKeys())) {
+                    return@parZip SavedEvent(event.id!!, SaveEventMessage.PROPERTIES_MISMATCH)
+                }
+                setCampaignEvent(campaign, event)
+                SavedEvent(event.id!!, SaveEventMessage.EVENT_SAVE_WITH_CAMPAIGN)
+            } ?: SavedEvent(event.id!!, SaveEventMessage.EVENT_SAVE_SUCCESS)
+        }
+
+        return out { PostEventUseCaseOut(savedEvent.id, savedEvent.message) }
+    }
+
+    private suspend fun saveEvent(
+        eventName: String,
+        userId: Long,
+        properties: List<PostEventPropertyDto>
+    ): Event {
+        return eventRepository.save(
             Event(
                 name = eventName,
                 userId = userId,
@@ -38,7 +83,21 @@ class PostEventUseCase(
                 )
             )
         )
+    }
 
-        return out { PostEventUseCaseOut(savedEvent.id!!) }
+    private suspend fun findCampaign(campaignName: String?): Campaign? {
+        return campaignName?.let {
+            campaignRepository.findCampaignByName(it)
+                ?: throw IllegalArgumentException("Campaign not found: $it")
+        }
+    }
+
+    private suspend fun setCampaignEvent(campaign: Campaign, savedEvent: Event) {
+        campaignEventsRepository.save(
+            CampaignEvents(
+                campaignId = campaign.id!!,
+                eventId = savedEvent.id!!
+            )
+        )
     }
 }

--- a/backend/src/main/kotlin/com/manage/crm/event/application/dto/PostEventUseCaseDto.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/dto/PostEventUseCaseDto.kt
@@ -2,6 +2,7 @@ package com.manage.crm.event.application.dto
 
 data class PostEventUseCaseIn(
     val name: String,
+    val campaignName: String?,
     val externalId: String,
     val properties: List<PostEventPropertyDto>
 )
@@ -12,6 +13,7 @@ data class PostEventPropertyDto(
 )
 
 data class PostEventUseCaseOut(
-    val id: Long
+    val id: Long,
+    val message: String
 )
 class PostEventUseCaseDto

--- a/backend/src/main/kotlin/com/manage/crm/event/controller/EventController.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/controller/EventController.kt
@@ -50,6 +50,7 @@ class EventController(
             .execute(
                 PostEventUseCaseIn(
                     name = request.name,
+                    campaignName = request.campaignName,
                     externalId = request.externalId,
                     properties = request.properties.map {
                         PostEventPropertyDto(

--- a/backend/src/main/kotlin/com/manage/crm/event/controller/request/PostEventRequest.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/controller/request/PostEventRequest.kt
@@ -2,6 +2,7 @@ package com.manage.crm.event.controller.request
 
 data class PostEventRequest(
     val name: String,
+    val campaignName: String?,
     val externalId: String,
     val properties: List<PostEventPropertyDto>
 )

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
@@ -16,4 +16,12 @@ class Campaign(
     var properties: Properties? = null,
     @Column("created_at")
     var createdAt: LocalDateTime? = null
-)
+) {
+    /**
+     * Check if the campaign has exactly the same property keys as the given list of keys.
+     */
+    fun allMatchPropertyKeys(keys: List<String>): Boolean {
+        val campaignPropertyKeys = properties?.getKeys() ?: return false
+        return campaignPropertyKeys.size == keys.size && campaignPropertyKeys.containsAll(keys)
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/repository/CampaignRepository.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/repository/CampaignRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 interface CampaignRepository : CoroutineCrudRepository<Campaign, Long> {
 
     suspend fun existsCampaignsByName(name: String): Boolean
+
+    suspend fun findCampaignByName(name: String): Campaign?
 }

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostEventUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostEventUseCaseTest.kt
@@ -2,12 +2,17 @@ package com.manage.crm.event.application
 
 import com.manage.crm.event.application.dto.PostEventPropertyDto
 import com.manage.crm.event.application.dto.PostEventUseCaseIn
+import com.manage.crm.event.domain.Campaign
+import com.manage.crm.event.domain.CampaignEvents
 import com.manage.crm.event.domain.Event
+import com.manage.crm.event.domain.repository.CampaignEventsRepository
+import com.manage.crm.event.domain.repository.CampaignRepository
 import com.manage.crm.event.domain.repository.EventRepository
 import com.manage.crm.event.domain.vo.Properties
 import com.manage.crm.event.domain.vo.Property
 import com.manage.crm.user.domain.User
 import com.manage.crm.user.domain.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -17,13 +22,18 @@ import java.time.LocalDateTime.now
 
 class PostEventUseCaseTest : BehaviorSpec({
     lateinit var eventRepository: EventRepository
+    lateinit var campaignRepository: CampaignRepository
+    lateinit var campaignEventsRepository: CampaignEventsRepository
     lateinit var userRepository: UserRepository
     lateinit var postEventUseCase: PostEventUseCase
 
     beforeContainer {
         eventRepository = mockk()
+        campaignRepository = mockk()
+        campaignEventsRepository = mockk()
         userRepository = mockk()
-        postEventUseCase = PostEventUseCase(eventRepository, userRepository)
+        postEventUseCase =
+            PostEventUseCase(eventRepository, campaignRepository, campaignEventsRepository, userRepository)
     }
 
     given("PostEventUseCase") {
@@ -40,7 +50,8 @@ class PostEventUseCaseTest : BehaviorSpec({
                         key = "key2",
                         value = "value2"
                     )
-                )
+                ),
+                campaignName = null
             )
 
             val user = User(
@@ -71,6 +82,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             val result = postEventUseCase.execute(useCaseIn)
             then("should return PostEventUseCaseOut") {
                 result.id shouldBe 1
+                result.message shouldBe SaveEventMessage.EVENT_SAVE_SUCCESS.message
             }
 
             then("find user by externalId") {
@@ -79,6 +91,255 @@ class PostEventUseCaseTest : BehaviorSpec({
 
             then("save event") {
                 coVerify(exactly = 1) { eventRepository.save(any(Event::class)) }
+            }
+        }
+
+        `when`("post event with campaign") {
+            val properties = listOf(
+                PostEventPropertyDto(
+                    key = "key1",
+                    value = "value1"
+                ),
+                PostEventPropertyDto(
+                    key = "key2",
+                    value = "value2"
+                )
+            )
+            val useCaseIn = PostEventUseCaseIn(
+                name = "event",
+                externalId = "1",
+                properties = properties,
+                campaignName = "campaign"
+            )
+
+            val user = User(
+                id = 1L,
+                externalId = useCaseIn.externalId
+            )
+            coEvery { userRepository.findByExternalId(useCaseIn.externalId) } answers { user }
+
+            val event = Event(
+                name = useCaseIn.name,
+                userId = user.id,
+                properties = Properties(
+                    useCaseIn.properties.map {
+                        Property(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }.toList()
+                )
+            )
+            val eventId = 1L
+            coEvery { eventRepository.save(any(Event::class)) } answers {
+                event.apply {
+                    id = eventId
+                    createdAt = now()
+                }
+            }
+
+            val campaignName = useCaseIn.campaignName!!
+            val campaignId = 1L
+            val campaign = Campaign(
+                id = campaignId,
+                name = campaignName,
+                properties = Properties(
+                    properties.map {
+                        Property(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }.toList()
+                )
+            )
+            coEvery { campaignRepository.findCampaignByName(campaignName) } answers { campaign }
+
+            val campaignEvents = CampaignEvents(
+                campaignId = campaignId,
+                eventId = eventId
+            )
+            coEvery { campaignEventsRepository.save(any(CampaignEvents::class)) } answers { campaignEvents }
+
+            val result = postEventUseCase.execute(useCaseIn)
+            then("should return PostEventUseCaseOut") {
+                result.id shouldBe eventId
+                result.message shouldBe SaveEventMessage.EVENT_SAVE_WITH_CAMPAIGN.message
+            }
+
+            then("find user by externalId") {
+                coVerify(exactly = 1) { userRepository.findByExternalId(useCaseIn.externalId) }
+            }
+
+            then("save event") {
+                coVerify(exactly = 1) { eventRepository.save(any(Event::class)) }
+            }
+
+            then("find campaign by name") {
+                coVerify(exactly = 1) { campaignRepository.findCampaignByName(campaignName) }
+            }
+
+            then("set campaign and event") {
+                coVerify(exactly = 1) { campaignEventsRepository.save(any(CampaignEvents::class)) }
+            }
+        }
+
+        `when`("post event with not found campaign") {
+            val properties = listOf(
+                PostEventPropertyDto(
+                    key = "key1",
+                    value = "value1"
+                ),
+                PostEventPropertyDto(
+                    key = "key2",
+                    value = "value2"
+                )
+            )
+            val useCaseIn = PostEventUseCaseIn(
+                name = "event",
+                externalId = "1",
+                properties = properties,
+                campaignName = "campaign"
+            )
+
+            val user = User(
+                id = 1L,
+                externalId = useCaseIn.externalId
+            )
+            coEvery { userRepository.findByExternalId(useCaseIn.externalId) } answers { user }
+
+            val event = Event(
+                name = useCaseIn.name,
+                userId = user.id,
+                properties = Properties(
+                    useCaseIn.properties.map {
+                        Property(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }.toList()
+                )
+            )
+            val eventId = 1L
+            coEvery { eventRepository.save(any(Event::class)) } answers {
+                event.apply {
+                    id = eventId
+                    createdAt = now()
+                }
+            }
+
+            val campaignName = useCaseIn.campaignName!!
+            coEvery { campaignRepository.findCampaignByName(campaignName) } answers { null }
+
+            val exception = shouldThrow<IllegalArgumentException> {
+                postEventUseCase.execute(useCaseIn)
+            }
+            then("should throw exception") {
+                exception.message shouldBe "Campaign not found: $campaignName"
+            }
+
+            then("find user by externalId") {
+                coVerify(exactly = 1) { userRepository.findByExternalId(useCaseIn.externalId) }
+            }
+
+            then("save event") {
+                coVerify(exactly = 1) { eventRepository.save(any(Event::class)) }
+            }
+
+            then("find campaign by name") {
+                coVerify(exactly = 1) { campaignRepository.findCampaignByName(campaignName) }
+            }
+
+            then("can't set campaign and event case campaign not found") {
+                coVerify(exactly = 0) { campaignEventsRepository.save(any(CampaignEvents::class)) }
+            }
+        }
+
+        `when`("post event with campaign but not all match property keys") {
+            val properties = listOf(
+                PostEventPropertyDto(
+                    key = "key1",
+                    value = "value1"
+                ),
+                PostEventPropertyDto(
+                    key = "key2",
+                    value = "value2"
+                )
+            )
+            val useCaseIn = PostEventUseCaseIn(
+                name = "event",
+                externalId = "1",
+                properties = properties,
+                campaignName = "campaign"
+            )
+
+            val user = User(
+                id = 1L,
+                externalId = useCaseIn.externalId
+            )
+            coEvery { userRepository.findByExternalId(useCaseIn.externalId) } answers { user }
+
+            val event = Event(
+                name = useCaseIn.name,
+                userId = user.id,
+                properties = Properties(
+                    useCaseIn.properties.map {
+                        Property(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }.toList()
+                )
+            )
+            val eventId = 1L
+            coEvery { eventRepository.save(any(Event::class)) } answers {
+                event.apply {
+                    id = eventId
+                    createdAt = now()
+                }
+            }
+
+            val notMatchProperties = listOf(
+                PostEventPropertyDto(
+                    key = "key1",
+                    value = "value1"
+                )
+            )
+            val campaignName = useCaseIn.campaignName!!
+            val campaignId = 1L
+            val campaign = Campaign(
+                id = campaignId,
+                name = campaignName,
+                properties = Properties(
+                    notMatchProperties.map {
+                        Property(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }.toList()
+                )
+            )
+            coEvery { campaignRepository.findCampaignByName(campaignName) } answers { campaign }
+
+            val result = postEventUseCase.execute(useCaseIn)
+            then("should return PostEventUseCaseOut") {
+                result.id shouldBe eventId
+                result.message shouldBe SaveEventMessage.PROPERTIES_MISMATCH.message
+            }
+
+            then("find user by externalId") {
+                coVerify(exactly = 1) { userRepository.findByExternalId(useCaseIn.externalId) }
+            }
+
+            then("save event") {
+                coVerify(exactly = 1) { eventRepository.save(any(Event::class)) }
+            }
+
+            then("find campaign by name") {
+                coVerify(exactly = 1) { campaignRepository.findCampaignByName(campaignName) }
+            }
+
+            then("can't set campaign and event cause property keys not match") {
+                coVerify(exactly = 0) { campaignEventsRepository.save(any(CampaignEvents::class)) }
             }
         }
     }

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostEventUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostEventUseCaseTest.kt
@@ -230,11 +230,10 @@ class PostEventUseCaseTest : BehaviorSpec({
             val campaignName = useCaseIn.campaignName!!
             coEvery { campaignRepository.findCampaignByName(campaignName) } answers { null }
 
-            val exception = shouldThrow<IllegalArgumentException> {
-                postEventUseCase.execute(useCaseIn)
-            }
-            then("should throw exception") {
-                exception.message shouldBe "Campaign not found: $campaignName"
+            val result = postEventUseCase.execute(useCaseIn)
+            then("return PostEventUseCaseOut") {
+                result.id shouldBe eventId
+                result.message shouldBe SaveEventMessage.EVENT_SAVE_BUT_NOT_CAMPAIGN.message
             }
 
             then("find user by externalId") {

--- a/backend/src/test/kotlin/com/manage/crm/event/domain/CampaignTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/domain/CampaignTest.kt
@@ -1,0 +1,97 @@
+package com.manage.crm.event.domain
+
+import com.manage.crm.event.domain.vo.Properties
+import com.manage.crm.event.domain.vo.Property
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+
+class CampaignTest : FeatureSpec({
+    feature("Campaign#allMatchPropertyKeys") {
+        scenario("all match property keys") {
+            // given
+            val campaign = Campaign(
+                properties = Properties(
+                    value = listOf(
+                        Property("key1", "value1"),
+                        Property("key2", "value2")
+                    )
+                )
+            )
+
+            // when
+            val result = campaign.allMatchPropertyKeys(listOf("key1", "key2"))
+
+            // then
+            result shouldBe true
+        }
+
+        scenario("not all match property keys - same size") {
+            // given
+            val campaign = Campaign(
+                properties = Properties(
+                    value = listOf(
+                        Property("key1", "value1"),
+                        Property("key2", "value2")
+                    )
+                )
+            )
+
+            // when
+            val result = campaign.allMatchPropertyKeys(listOf("key1", "key3"))
+
+            // then
+            result shouldBe false
+        }
+
+        scenario("not all match property keys - different size") {
+            // given
+            val campaign = Campaign(
+                properties = Properties(
+                    value = listOf(
+                        Property("key1", "value1"),
+                        Property("key2", "value2")
+                    )
+                )
+            )
+
+            // when
+            val result = campaign.allMatchPropertyKeys(listOf("key1"))
+
+            // then
+            result shouldBe false
+        }
+
+        scenario("not all match property keys - empty campaign properties") {
+            // given
+            val campaign = Campaign(
+                properties = Properties(
+                    value = emptyList()
+                )
+            )
+
+            // when
+            val result = campaign.allMatchPropertyKeys(listOf("key1", "key2"))
+
+            // then
+            result shouldBe false
+        }
+
+        scenario("not all match property keys - empty input keys") {
+            // given
+            val campaign = Campaign(
+                properties = Properties(
+                    value = listOf(
+                        Property("key1", "value1"),
+                        Property("key2", "value2")
+                    )
+                )
+            )
+
+            // when
+            val result = campaign.allMatchPropertyKeys(emptyList())
+
+            // then
+            result shouldBe false
+        }
+    }
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
	- 이벤트 등록 시 캠페인 이름을 선택적으로 제공할 수 있어, 관련 캠페인과의 연계를 강화하였습니다.
	- 이벤트 저장 처리 방식이 개선되어, 이벤트 생성과 캠페인 조회가 동시 실행되며, 보다 명확한 결과 메시지를 제공합니다.
	- 요청 및 응답 구조가 확장되어, 추가 정보와 메시지가 포함됩니다.
	- 캠페인 속성 키 일치 여부를 검증하는 새로운 메서드가 추가되었습니다.

- **버그 수정**
	- 캠페인이 존재하지 않을 경우 적절한 오류 처리가 추가되었습니다.

- **테스트**
	- 캠페인 연계, 속성 키 일치 검증, 캠페인 부재 오류 처리 등 새로운 시나리오에 대한 테스트 케이스를 추가하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->