### PR TITLE
[Fix/#66] EventModuleTestTemplate 테스트 중 SQS 구성 자동 설정 문제 해결

### DIFF
--- a/backend/src/test/kotlin/com/manage/crm/event/EventModuleTestTemplate.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/EventModuleTestTemplate.kt
@@ -1,6 +1,7 @@
 package com.manage.crm.event
 
 import com.manage.crm.config.TestTransactionConfiguration
+import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -10,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles(value = ["test", "new"])
 @EnableAutoConfiguration(
-    exclude = [FlywayAutoConfiguration::class]
+    exclude = [FlywayAutoConfiguration::class, SqsAutoConfiguration::class]
 )
 @ApplicationModuleTest(
     module = "event",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
    - 이벤트 모듈 테스트 실행 시 AWS SQS 자동 구성이 제외되어 테스트 환경이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->