### PR TITLE
[Refactor/#67] ScheduledEvent 도메인 createAt 칼럼 추가

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/email/domain/ScheduledEvent.kt
+++ b/backend/src/main/kotlin/com/manage/crm/email/domain/ScheduledEvent.kt
@@ -24,7 +24,9 @@ class ScheduledEvent(
     @Column("canceled")
     var canceled: Boolean = false,
     @Column("scheduled_at")
-    val scheduledAt: String? = null
+    val scheduledAt: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null
 ) {
     companion object {
         fun new(
@@ -52,6 +54,7 @@ class ScheduledEvent(
             isNotConsumed: Boolean,
             canceled: Boolean,
             scheduledAt: String,
+            createdAt: LocalDateTime
         ): ScheduledEvent {
             return ScheduledEvent(
                 id = id,
@@ -61,7 +64,8 @@ class ScheduledEvent(
                 completed = completed,
                 isNotConsumed = isNotConsumed,
                 canceled = canceled,
-                scheduledAt = scheduledAt
+                scheduledAt = scheduledAt,
+                createdAt = createdAt
             )
         }
     }

--- a/backend/src/main/kotlin/com/manage/crm/email/domain/repository/ScheduledEventCustomRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/manage/crm/email/domain/repository/ScheduledEventCustomRepositoryImpl.kt
@@ -33,6 +33,7 @@ class ScheduledEventCustomRepositoryImpl(
                     isNotConsumed = it["is_not_consumed"] as Boolean,
                     canceled = it["canceled"] as Boolean,
                     scheduledAt = it["scheduled_at"] as String,
+                    createdAt = it["created_at"] as LocalDateTime
                 )
             }.collectList().awaitFirst()
     }

--- a/backend/src/main/resources/db/migration/entity/V1.00.0.8__add_scheduled_events_created_at_column.sql
+++ b/backend/src/main/resources/db/migration/entity/V1.00.0.8__add_scheduled_events_created_at_column.sql
@@ -1,0 +1,1 @@
+alter table  scheduled_events add column created_at datetime(6) null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 예약 이벤트에 생성일(`createdAt`) 정보가 추가되어 확인할 수 있습니다.

- **버그 수정**
  - 예약 이벤트 목록 조회 시 생성일 정보가 함께 표시됩니다.

- **기타**
  - 예약 이벤트 테이블에 생성일 컬럼이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->