### PR TITLE
[Feat/#53] SearchEventsUseCase의 이벤트 반환시 생성 요청에서의 external_id를 동일하게 반환하도록 구현

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/event/application/SearchEventsUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/SearchEventsUseCase.kt
@@ -47,7 +47,7 @@ class SearchEventsUseCase(
                 EventDto(
                     it.id!!,
                     it.name!!,
-                    users[it.userId!!]?.externalId,
+                    it.userId?.let { users[it]?.externalId },
                     it.properties!!.value.map { SearchEventPropertyDto(it.key, it.value) }.toList(),
                     it.createdAt!!
                 )

--- a/backend/src/main/kotlin/com/manage/crm/event/application/SearchEventsUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/SearchEventsUseCase.kt
@@ -12,16 +12,21 @@ import com.manage.crm.event.domain.repository.query.SearchByPropertyQuery
 import com.manage.crm.event.domain.vo.Properties
 import com.manage.crm.event.domain.vo.Property
 import com.manage.crm.support.out
+import com.manage.crm.user.domain.repository.UserRepository
 import org.springframework.stereotype.Service
 
 /**
  *  - `events`: `eventName`과 `properties`를 기준으로 `Event`를 검색한 결과
  *      - `eventName`은 필수 검색 조건
  *      - `properties`와 `propertyOperations`를 조홥하여 여러 조건의 검색 가능
+ *  - `users`: `events`에 포함된 `userId`를 기준으로 `User`를 검색한 결과
+ *  - `eventDto`: `events`와 `users`를 조합하여 생성한 DTO
+ *      - `externalId`는 `User`가 삭제 된 경우 조회 하지 못할 수 있다. 해당 경우 `null`로 처리한다.
  */
 @Service
 class SearchEventsUseCase(
-    private val eventRepository: EventRepository
+    private val eventRepository: EventRepository,
+    private val userRepository: UserRepository
 ) {
     suspend fun execute(useCaseIn: SearchEventsUseCaseIn): SearchEventsUseCaseOut {
         val eventName = useCaseIn.eventName
@@ -34,11 +39,15 @@ class SearchEventsUseCase(
 
         val events = searchEvents(eventName, propertyOperations)
 
+        val userIds = events.mapNotNull { it.userId }.toSet().toList()
+        val users = userRepository.findAllByIdIn(userIds).associateBy { it.id }
+
         return out {
             events.map { it ->
                 EventDto(
                     it.id!!,
                     it.name!!,
+                    users[it.userId!!]?.externalId,
                     it.properties!!.value.map { SearchEventPropertyDto(it.key, it.value) }.toList(),
                     it.createdAt!!
                 )

--- a/backend/src/main/kotlin/com/manage/crm/event/application/dto/SearchEventsUseCaseDto.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/dto/SearchEventsUseCaseDto.kt
@@ -27,6 +27,7 @@ data class SearchEventsUseCaseOut(
 data class EventDto(
     val id: Long,
     val name: String,
+    val externalId: String?,
     val properties: List<SearchEventPropertyDto>,
     val createdAt: LocalDateTime
 )

--- a/backend/src/test/kotlin/com/manage/crm/event/application/SearchEventsUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/SearchEventsUseCaseTest.kt
@@ -10,6 +10,9 @@ import com.manage.crm.event.domain.repository.EventRepository
 import com.manage.crm.event.domain.repository.query.SearchByPropertyQuery
 import com.manage.crm.event.domain.vo.Properties
 import com.manage.crm.event.domain.vo.Property
+import com.manage.crm.user.domain.User
+import com.manage.crm.user.domain.repository.UserRepository
+import com.manage.crm.user.domain.vo.Json
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -19,11 +22,13 @@ import java.time.LocalDateTime
 
 class SearchEventsUseCaseTest : BehaviorSpec({
     lateinit var eventRepository: EventRepository
+    lateinit var userRepository: UserRepository
     lateinit var searchEventsUseCase: SearchEventsUseCase
 
     beforeContainer {
         eventRepository = mockk()
-        searchEventsUseCase = SearchEventsUseCase(eventRepository)
+        userRepository = mockk()
+        searchEventsUseCase = SearchEventsUseCase(eventRepository, userRepository)
     }
 
     given("SearchEventsUseCase") {
@@ -62,6 +67,21 @@ class SearchEventsUseCaseTest : BehaviorSpec({
                 events
             }
 
+            val userIds = events.mapNotNull { it.userId }.toSet().toList()
+            val users = userIds.map {
+                User.new(
+                    id = it,
+                    externalId = "externalId-$it",
+                    userAttributes = Json("""{}""".trimIndent()),
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                )
+            }.toList()
+
+            coEvery { userRepository.findAllByIdIn(userIds) } answers {
+                users
+            }
+
             val result = searchEventsUseCase.execute(useCaseIn)
             then("should return SearchEventsUseCaseOut") {
                 result.events.size shouldBe eventSize
@@ -69,6 +89,10 @@ class SearchEventsUseCaseTest : BehaviorSpec({
 
             then("search events with property") {
                 coVerify(exactly = 1) { eventRepository.searchByProperty(any(SearchByPropertyQuery::class)) }
+            }
+
+            then("find all users by events userIds") {
+                coVerify(exactly = 1) { userRepository.findAllByIdIn(userIds) }
             }
         }
 
@@ -118,6 +142,21 @@ class SearchEventsUseCaseTest : BehaviorSpec({
                 events
             }
 
+            val userIds = events.mapNotNull { it.userId }.toSet().toList()
+            val users = userIds.map {
+                User.new(
+                    id = it,
+                    externalId = "externalId-$it",
+                    userAttributes = Json("""{}""".trimIndent()),
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                )
+            }.toList()
+
+            coEvery { userRepository.findAllByIdIn(userIds) } answers {
+                users
+            }
+
             val result = searchEventsUseCase.execute(useCaseIn)
             then("should return SearchEventsUseCaseOut") {
                 result.events.size shouldBe eventSize
@@ -125,6 +164,10 @@ class SearchEventsUseCaseTest : BehaviorSpec({
 
             then("search events with properties") {
                 coVerify(exactly = 1) { eventRepository.searchByProperties(any()) }
+            }
+
+            then("find all users by events userIds") {
+                coVerify(exactly = 1) { userRepository.findAllByIdIn(userIds) }
             }
         }
 
@@ -150,6 +193,21 @@ class SearchEventsUseCaseTest : BehaviorSpec({
                 events
             }
 
+            val userIds = events.mapNotNull { it.userId }.toSet().toList()
+            val users = userIds.map {
+                User.new(
+                    id = it,
+                    externalId = "externalId-$it",
+                    userAttributes = Json("""{}""".trimIndent()),
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                )
+            }.toList()
+
+            coEvery { userRepository.findAllByIdIn(userIds) } answers {
+                users
+            }
+
             val result = searchEventsUseCase.execute(useCaseIn)
             then("should return SearchEventsUseCaseOut") {
                 result.events.size shouldBe eventSize
@@ -157,6 +215,10 @@ class SearchEventsUseCaseTest : BehaviorSpec({
 
             then("search events with name") {
                 coVerify(exactly = 1) { eventRepository.findAllByName(any()) }
+            }
+
+            then("find all users by events userIds") {
+                coVerify(exactly = 1) { userRepository.findAllByIdIn(userIds) }
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 검색 결과에 각 이벤트와 연관된 사용자의 외부 ID(externalId)가 표시됩니다. 사용자가 삭제된 경우 해당 값은 비어 있을 수 있습니다.

- **버그 수정**
  - 이벤트와 연결된 사용자 정보가 없는 경우에도 검색 결과가 정상적으로 반환됩니다.

- **테스트**
  - 사용자 정보 조회와 관련된 테스트가 추가되어 이벤트와 사용자 데이터의 연계가 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->