### PR TITLE
[Refactor/#56] UseCase 테스트에서 예외 발생시 수행되지 않는 메서드 검증 추가

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/email/application/SendNotificationEmailUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/email/application/SendNotificationEmailUseCase.kt
@@ -79,9 +79,7 @@ class SendNotificationEmailUseCase(
                             body = it.body,
                             variables = it.variables
                         )
-                    }
-                    ?: NotFoundByException("EmailTemplate", "templateId", templateId, "version", templateVersion)
-                        .let { throw it } // TODO: Exception Handling
+                    } ?: throw NotFoundByException("EmailTemplate", "templateId", templateId, "version", templateVersion)
             }
 
             else -> {

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.manage.crm.event.domain.Campaign
 import com.manage.crm.event.domain.repository.CampaignRepository
 import com.manage.crm.event.domain.vo.Properties
 import com.manage.crm.event.domain.vo.Property
+import com.manage.crm.support.exception.AlreadyExistsException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.ints.exactly
@@ -90,7 +91,7 @@ class PostCampaignUseCaseTest : BehaviorSpec({
             coEvery { campaignRepository.existsCampaignsByName(useCaseIn.name) } returns true
 
             then("should throw exception") {
-                val exception = shouldThrow<IllegalArgumentException> {
+                val exception = shouldThrow<AlreadyExistsException> {
                     postCampaignUseCase.execute(useCaseIn)
                 }
 
@@ -99,6 +100,10 @@ class PostCampaignUseCaseTest : BehaviorSpec({
 
             then("check campaign name is exists") {
                 coVerify(exactly = 1) { campaignRepository.existsCampaignsByName(useCaseIn.name) }
+            }
+
+            then("not called save campaign") {
+                coVerify(exactly = 0) { campaignRepository.save(any(Campaign::class)) }
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이메일 알림 템플릿 버전이 없을 때의 예외 처리 로직이 간소화되었습니다.

- **테스트**
  - 중복된 이메일 템플릿 이름 생성 시 예외 발생 여부를 확인하는 테스트가 추가되었습니다.
  - 이메일 템플릿 또는 버전이 없을 때 올바른 예외가 발생하고, 불필요한 저장 및 이메일 전송이 일어나지 않는지 확인하는 테스트가 추가되었습니다.
  - 캠페인 이름이 중복될 때 저장 동작이 일어나지 않는지 검증하는 테스트가 개선되었습니다.
  - 존재하지 않는 사용자 외부 ID로 이벤트 등록 시 예외가 발생하고, 이벤트가 저장되지 않는지 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->