### PR TITLE
[Feat/#58] 캠페인 이름을 통해 캠페인 아이디 조회 캐싱 적용

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/event/application/PostEventUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/PostEventUseCase.kt
@@ -124,7 +124,7 @@ class PostEventUseCase(
 
     private suspend fun findCampaign(campaignName: String?): Campaign? {
         return campaignName?.let { name ->
-            campaignCacheManager.loadAndSaveIfMiss(Campaign.UNIQUE_FIEDS.NAME, name) {
+            campaignCacheManager.loadAndSaveIfMiss(Campaign.UNIQUE_FIELDS.NAME, name) {
                 campaignRepository.findCampaignByName(name) ?: throw NotFoundByException("Campaign", "name", name)
             }
         }

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
@@ -32,7 +32,7 @@ class Campaign(
         createdAt = createdAt
     )
 
-    object UNIQUE_FIEDS {
+    object UNIQUE_FIELDS {
         const val NAME = "name"
     }
 

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/Campaign.kt
@@ -1,5 +1,7 @@
 package com.manage.crm.event.domain
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.manage.crm.event.domain.vo.Properties
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
@@ -7,6 +9,7 @@ import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 
+// TODO add name unique constraint
 @Table("campaigns")
 class Campaign(
     @Id
@@ -18,6 +21,21 @@ class Campaign(
     @CreatedDate
     var createdAt: LocalDateTime? = null
 ) {
+    @JsonCreator private constructor(
+        @JsonProperty("id") id: Long,
+        @JsonProperty("name") name: String,
+        @JsonProperty("createdAt") createdAt: LocalDateTime
+    ) : this(
+        id = id,
+        name = name,
+        properties = Properties(emptyList()),
+        createdAt = createdAt
+    )
+
+    object UNIQUE_FIEDS {
+        const val NAME = "name"
+    }
+
     companion object {
         fun new(
             name: String,

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/cache/CampaignCacheManager.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/cache/CampaignCacheManager.kt
@@ -1,0 +1,106 @@
+package com.manage.crm.event.domain.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.manage.crm.event.domain.Campaign
+import com.manage.crm.event.domain.vo.Properties
+import com.manage.crm.event.domain.vo.Property
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.hash.Jackson2HashMapper
+import org.springframework.stereotype.Service
+
+@Service
+class CampaignCacheManager(
+    private val redisTemplate: ReactiveRedisTemplate<String, Any>,
+    private val mapper: Jackson2HashMapper,
+    private val objectMapper: ObjectMapper
+) {
+    val log = KotlinLogging.logger {}
+    companion object {
+        private const val SPLIT = "::"
+        private const val CAMPAIGN_CACHE_KEY = "campaign"
+        const val CAMPAIGN_CACHE_KEY_PREFIX = CAMPAIGN_CACHE_KEY + SPLIT
+        private const val CAMPAIGN_PROPERTIES_KEY = "properties"
+        const val CAMPAIGN_PROPERTIES_KEY_PREFIX = CAMPAIGN_PROPERTIES_KEY + SPLIT
+    }
+
+    fun toHash(campaign: Campaign): Map<String, Any> {
+        return mapper.toHash(campaign).also {
+            campaign.properties.value.forEach { property ->
+                it["${CAMPAIGN_PROPERTIES_KEY_PREFIX}${property.key}"] = property.value
+            }
+        }
+    }
+
+    fun loadHash(hash: Map<String, Any>): Campaign {
+        val properties = hash.filterKeys { it.startsWith(CAMPAIGN_PROPERTIES_KEY_PREFIX) }
+            .mapKeys { it.key.removePrefix(CAMPAIGN_PROPERTIES_KEY_PREFIX) }
+            .mapValues { it.value.toString() }
+        val campaignPropertiesMap = properties.map { (key, value) ->
+            Property(key = key, value = value)
+        }
+        return objectMapper.convertValue(hash, Campaign::class.java).also {
+            it.properties = Properties(campaignPropertiesMap)
+        }
+    }
+
+    suspend fun save(campaign: Campaign): Campaign {
+        saveWithId(campaign)
+        saveWithName(campaign)
+        log.debug { "Successfully saved campaign as campaign:${campaign.id}" }
+        return campaign
+    }
+
+    private suspend fun saveWithId(campaign: Campaign) {
+        redisTemplate.opsForHash<String, Any>()
+            .putAll("${CAMPAIGN_CACHE_KEY_PREFIX}${campaign.id}", toHash(campaign))
+            .awaitSingle()
+    }
+
+    private suspend fun saveWithName(campaign: Campaign) {
+        redisTemplate.opsForValue()
+            .set("${CAMPAIGN_CACHE_KEY_PREFIX}${Campaign.UNIQUE_FIEDS.NAME}${SPLIT}${campaign.name}", campaign.id!!)
+            .awaitSingle()
+    }
+
+    suspend fun load(id: Long): Campaign? {
+        val hash = mutableMapOf<String, Any>()
+        val keys = redisTemplate.opsForHash<String, Any>().keys("${CAMPAIGN_CACHE_KEY_PREFIX}$id").collectList().awaitSingle()
+        for (prop in keys) {
+            redisTemplate.opsForHash<String, Any>()
+                .get("${CAMPAIGN_CACHE_KEY_PREFIX}$id", prop)
+                .awaitSingleOrNull()
+                ?.let { hash[prop] = it }
+        }
+        return if (hash.isNotEmpty()) {
+            loadHash(hash)
+        } else {
+            log.warn { "Campaign with id:$id not found in cache" }
+            null
+        }
+    }
+
+    suspend fun loadAndSaveIfMiss(id: Long, findForLoad: suspend () -> Campaign?): Campaign? {
+        return load(id) ?: run {
+            findForLoad.invoke()
+                ?.also { save(it) }
+        }
+    }
+
+    suspend fun load(uniqKey: String, value: String): Campaign? {
+        return redisTemplate.opsForValue().get("${CAMPAIGN_CACHE_KEY_PREFIX}$uniqKey${SPLIT}$value")
+            .awaitSingleOrNull()
+            ?.toString()
+            ?.toLong()
+            ?.let { load(it) }
+    }
+
+    suspend fun loadAndSaveIfMiss(uniqKey: String, value: String, findForLoad: suspend () -> Campaign?): Campaign? {
+        return load(uniqKey, value) ?: run {
+            findForLoad.invoke()
+                ?.also { save(it) }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/event/domain/cache/CampaignCacheManager.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/domain/cache/CampaignCacheManager.kt
@@ -61,7 +61,7 @@ class CampaignCacheManager(
 
     private suspend fun saveWithName(campaign: Campaign) {
         redisTemplate.opsForValue()
-            .set("${CAMPAIGN_CACHE_KEY_PREFIX}${Campaign.UNIQUE_FIEDS.NAME}${SPLIT}${campaign.name}", campaign.id!!)
+            .set("${CAMPAIGN_CACHE_KEY_PREFIX}${Campaign.UNIQUE_FIELDS.NAME}${SPLIT}${campaign.name}", campaign.id!!)
             .awaitSingle()
     }
 

--- a/backend/src/main/kotlin/com/manage/crm/support/transactional/TransactionSynchronizationTemplate.kt
+++ b/backend/src/main/kotlin/com/manage/crm/support/transactional/TransactionSynchronizationTemplate.kt
@@ -1,0 +1,34 @@
+package com.manage.crm.support.transactional
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.mono
+import org.springframework.stereotype.Service
+import org.springframework.transaction.reactive.TransactionSynchronization
+import org.springframework.transaction.reactive.TransactionSynchronizationManager
+import reactor.core.publisher.Mono
+import kotlin.coroutines.CoroutineContext
+
+@Service
+class TransactionSynchronizationTemplate {
+    val log = KotlinLogging.logger {}
+
+    suspend fun afterCompletion(
+        context: CoroutineContext = Dispatchers.IO,
+        blockDescription: String,
+        block: suspend () -> Unit
+    ) {
+        TransactionSynchronizationManager.forCurrentTransaction().map { manager ->
+            manager.registerSynchronization(object : TransactionSynchronization {
+                override fun afterCompletion(status: Int): Mono<Void> {
+                    return mono(context) {
+                        log.debug { "do after completion: $blockDescription" }
+                        block()
+                        return@mono null
+                    }
+                }
+            })
+        }.awaitSingle()
+    }
+}

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
@@ -3,25 +3,33 @@ package com.manage.crm.event.application
 import com.manage.crm.event.application.dto.PostCampaignPropertyDto
 import com.manage.crm.event.application.dto.PostCampaignUseCaseIn
 import com.manage.crm.event.domain.Campaign
+import com.manage.crm.event.domain.cache.CampaignCacheManager
 import com.manage.crm.event.domain.repository.CampaignRepository
 import com.manage.crm.event.domain.vo.Properties
 import com.manage.crm.event.domain.vo.Property
 import com.manage.crm.support.exception.AlreadyExistsException
+import com.manage.crm.support.transactional.TransactionSynchronizationTemplate
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.ints.exactly
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coInvoke
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
 
 class PostCampaignUseCaseTest : BehaviorSpec({
     lateinit var campaignRepository: CampaignRepository
+    lateinit var transactionSynchronizationTemplate: TransactionSynchronizationTemplate
+    lateinit var campaignCacheManager: CampaignCacheManager
     lateinit var postCampaignUseCase: PostCampaignUseCase
 
     beforeContainer {
         campaignRepository = mockk()
-        postCampaignUseCase = PostCampaignUseCase(campaignRepository)
+        transactionSynchronizationTemplate = mockk()
+        campaignCacheManager = mockk()
+        postCampaignUseCase =
+            PostCampaignUseCase(campaignRepository, transactionSynchronizationTemplate, campaignCacheManager)
     }
 
     given("PostCampaignUseCase") {
@@ -60,6 +68,18 @@ class PostCampaignUseCaseTest : BehaviorSpec({
                 }
             }
 
+            coEvery { campaignCacheManager.save(any()) } answers { savedCampaign }
+
+            coEvery {
+                transactionSynchronizationTemplate.afterCompletion(
+                    eq(Dispatchers.IO),
+                    eq("save campaign cache"),
+                    captureLambda<suspend () -> Unit>()
+                )
+            } coAnswers {
+                lambda<suspend () -> Unit>().coInvoke()
+            }
+
             val result = postCampaignUseCase.execute(useCaseIn)
 
             then("should return PostCampaignUseCaseOut") {
@@ -74,6 +94,20 @@ class PostCampaignUseCaseTest : BehaviorSpec({
 
             then("save campaign") {
                 coVerify(exactly = 1) { campaignRepository.save(any()) }
+            }
+
+            then("register transaction synchronization after completion for save campaign cache") {
+                coVerify(exactly = 1) {
+                    transactionSynchronizationTemplate.afterCompletion(
+                        eq(Dispatchers.IO),
+                        eq("save campaign cache"),
+                        captureLambda<suspend () -> Unit>()
+                    )
+                }
+            }
+
+            then("save campaign cache") {
+                coVerify(exactly = 1) { campaignCacheManager.save(any()) }
             }
         }
 
@@ -104,6 +138,20 @@ class PostCampaignUseCaseTest : BehaviorSpec({
 
             then("not called save campaign") {
                 coVerify(exactly = 0) { campaignRepository.save(any(Campaign::class)) }
+            }
+
+            then("not called register transaction synchronization after completion for save campaign cache") {
+                coVerify(exactly = 0) {
+                    transactionSynchronizationTemplate.afterCompletion(
+                        eq(Dispatchers.IO),
+                        eq("save campaign cache"),
+                        captureLambda<suspend () -> Unit>()
+                    )
+                }
+            }
+
+            then("not called save campaign cache") {
+                coVerify(exactly = 0) { campaignCacheManager.save(any()) }
             }
         }
     }

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostEventUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostEventUseCaseTest.kt
@@ -168,7 +168,7 @@ class PostEventUseCaseTest : BehaviorSpec({
 
             coEvery {
                 campaignCacheManager.loadAndSaveIfMiss(
-                    eq(Campaign.UNIQUE_FIEDS.NAME),
+                    eq(Campaign.UNIQUE_FIELDS.NAME),
                     eq(useCaseIn.campaignName!!),
                     captureLambda<suspend () -> Campaign?>()
                 )
@@ -199,7 +199,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             then("find campaign by name from cache. this is default") {
                 coVerify(exactly = 1) {
                     campaignCacheManager.loadAndSaveIfMiss(
-                        Campaign.UNIQUE_FIEDS.NAME,
+                        Campaign.UNIQUE_FIELDS.NAME,
                         useCaseIn.campaignName!!,
                         captureLambda<suspend () -> Campaign?>()
                     )
@@ -214,7 +214,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             `when`("post event with campaign. when campaign is not cached") {
                 coEvery {
                     campaignCacheManager.loadAndSaveIfMiss(
-                        eq(Campaign.UNIQUE_FIEDS.NAME),
+                        eq(Campaign.UNIQUE_FIELDS.NAME),
                         eq(useCaseIn.campaignName!!),
                         captureLambda<suspend () -> Campaign?>()
                     )
@@ -223,7 +223,7 @@ class PostEventUseCaseTest : BehaviorSpec({
                 }
                 coEvery { campaignRepository.findCampaignByName(campaignName) } answers { campaign }
 
-                campaignCacheManager.loadAndSaveIfMiss(Campaign.UNIQUE_FIEDS.NAME, useCaseIn.campaignName!!) {
+                campaignCacheManager.loadAndSaveIfMiss(Campaign.UNIQUE_FIELDS.NAME, useCaseIn.campaignName!!) {
                     campaignRepository.findCampaignByName(useCaseIn.campaignName!!)
                         ?: throw NotFoundByException("Campaign", "name", useCaseIn.campaignName!!)
                 }
@@ -231,7 +231,7 @@ class PostEventUseCaseTest : BehaviorSpec({
                 then("try to load campaign from cache and save if miss") {
                     coVerify(exactly = 1) {
                         campaignCacheManager.loadAndSaveIfMiss(
-                            Campaign.UNIQUE_FIEDS.NAME,
+                            Campaign.UNIQUE_FIELDS.NAME,
                             useCaseIn.campaignName!!,
                             captureLambda<suspend () -> Campaign?>()
                         )
@@ -291,7 +291,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             val campaignName = useCaseIn.campaignName!!
             coEvery {
                 campaignCacheManager.loadAndSaveIfMiss(
-                    eq(Campaign.UNIQUE_FIEDS.NAME),
+                    eq(Campaign.UNIQUE_FIELDS.NAME),
                     eq(useCaseIn.campaignName!!),
                     captureLambda<suspend () -> Campaign?>()
                 )
@@ -320,7 +320,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             then("try to load campaign from cache and try to find campaign by name") {
                 coVerify(exactly = 1) {
                     campaignCacheManager.loadAndSaveIfMiss(
-                        Campaign.UNIQUE_FIEDS.NAME,
+                        Campaign.UNIQUE_FIELDS.NAME,
                         useCaseIn.campaignName!!,
                         captureLambda<suspend () -> Campaign?>()
                     )
@@ -403,7 +403,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             )
             coEvery {
                 campaignCacheManager.loadAndSaveIfMiss(
-                    eq(Campaign.UNIQUE_FIEDS.NAME),
+                    eq(Campaign.UNIQUE_FIELDS.NAME),
                     eq(useCaseIn.campaignName!!),
                     captureLambda<suspend () -> Campaign?>()
                 )
@@ -428,7 +428,7 @@ class PostEventUseCaseTest : BehaviorSpec({
             then("find campaign by name from cache. this is default") {
                 coVerify(exactly = 1) {
                     campaignCacheManager.loadAndSaveIfMiss(
-                        Campaign.UNIQUE_FIEDS.NAME,
+                        Campaign.UNIQUE_FIELDS.NAME,
                         useCaseIn.campaignName!!,
                         captureLambda<suspend () -> Campaign?>()
                     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 캠페인 객체에 대한 Redis 기반 캐싱 기능이 추가되었습니다.
    - 트랜잭션 완료 후 비동기적으로 캠페인 캐시가 갱신됩니다.
    - 캠페인 도메인 객체의 JSON 역직렬화를 위한 생성자가 추가되었습니다.
    - 트랜잭션 완료 시점에 비동기 작업을 실행하는 기능이 도입되었습니다.

- **버그 수정**
    - 기존에 직접 저장소에서 조회하던 캠페인 로직이 캐시를 우선적으로 활용하도록 개선되었습니다.

- **테스트**
    - 캐시 매니저 및 트랜잭션 동기화 기능을 검증하는 테스트가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->