### PR TITLE
[Feat/#39] 유저 조회 API 응답에 생성, 수정 정보 추가

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/user/application/BrowseUserUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/user/application/BrowseUserUseCase.kt
@@ -23,7 +23,9 @@ class BrowseUserUseCase(
                     UserDto(
                         id = user.id!!,
                         externalId = user.externalId,
-                        userAttributes = user.userAttributes.value
+                        userAttributes = user.userAttributes.value,
+                        updatedAt = user.updatedAt!!,
+                        createdAt = user.createdAt!!
                     )
                 }
             )

--- a/backend/src/main/kotlin/com/manage/crm/user/application/dto/BrowseUsersUseCaseDto.kt
+++ b/backend/src/main/kotlin/com/manage/crm/user/application/dto/BrowseUsersUseCaseDto.kt
@@ -1,5 +1,7 @@
 package com.manage.crm.user.application.dto
 
+import java.time.LocalDateTime
+
 class BrowseUsersUseCaseIn
 
 data class BrowseUsersUseCaseOut(
@@ -8,6 +10,8 @@ data class BrowseUsersUseCaseOut(
 data class UserDto(
     val id: Long,
     val externalId: String,
-    val userAttributes: String
+    val userAttributes: String,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
 )
 class BrowseUsersUseCaseDto

--- a/backend/src/test/kotlin/com/manage/crm/user/application/BrowseUserUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/user/application/BrowseUserUseCaseTest.kt
@@ -53,8 +53,10 @@ class BrowseUserUseCaseTest : BehaviorSpec({
                     users = expectedUsers.map {
                         UserDto(
                             id = it.id!!,
-                            externalId = it.externalId!!,
-                            userAttributes = it.userAttributes?.value!!
+                            externalId = it.externalId,
+                            userAttributes = it.userAttributes.value,
+                            createdAt = it.createdAt!!,
+                            updatedAt = it.updatedAt!!
                         )
                     }
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보에 생성일(`createdAt`)과 마지막 수정일(`updatedAt`)이 추가되어, 사용자 목록 조회 시 해당 타임스탬프가 함께 제공됩니다.

- **테스트**
  - 사용자 정보에 생성일 및 수정일 필드가 포함되도록 테스트가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->