### PR TITLE
[Fix/#87] EnrollUserUseCase에서 수정이 저장되지 않던 문제 해결

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/user/application/EnrollUserUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/user/application/EnrollUserUseCase.kt
@@ -34,6 +34,7 @@ class EnrollUserUseCase(
                 userRepository
                     .findById(id)
                     ?.apply { updateAttributes(userAttributes) }
+                    ?.apply { userRepository.save(this) }
                     ?: throw NotFoundByIdException("User", id)
             } else {
                 userRepository.save(

--- a/backend/src/test/kotlin/com/manage/crm/user/application/EnrollUserUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/user/application/EnrollUserUseCaseTest.kt
@@ -116,6 +116,8 @@ class EnrollUserUseCaseTest : BehaviorSpec({
             originUser.updateAttributes(userUpdateAttributes)
             val expectedUser = originUser
 
+            coEvery { userRepository.save(any()) } returns expectedUser
+
             val result = useCase.execute(useCaseIn)
             then("should return EnrollUserUseCaseOut") {
                 result shouldBe EnrollUserUseCaseOut(
@@ -135,6 +137,11 @@ class EnrollUserUseCaseTest : BehaviorSpec({
             then("find user by id for update") {
                 coVerify(exactly = 1) {
                     userRepository.findById(useCaseIn.id!!)
+                }
+            }
+            then("update user") {
+                coVerify(exactly = 1) {
+                    userRepository.save(any())
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 기존 사용자 정보 수정 시 변경 사항이 올바르게 저장되도록 저장 동작을 명확히 추가했습니다.

- **테스트**
  - 사용자 정보 수정 시 저장 동작이 정확히 한 번 호출되는지 검증하는 테스트를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->