### PR TITLE
[Feat/#96] RE: 요청/응답 압축 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -78,6 +78,9 @@ dependencies {
     testRuntimeOnly("com.mysql:mysql-connector-j")
     testImplementation("com.zaxxer:HikariCP:${DependencyVersion.HIKARI_CP}")
 
+    /** commons-io */
+    implementation("commons-io:commons-io:${DependencyVersion.COMMONS_IO}")
+
     /** flyway */
     implementation("org.flywaydb:flyway-core:${DependencyVersion.FLYWAY}")
     implementation("org.flywaydb:flyway-mysql")

--- a/backend/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/backend/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -54,4 +54,8 @@ object DependencyVersion {
 
     /** Logger **/
     const val KOTLIN_LOGGING = "7.0.0"
+
+
+    /** commons-io **/
+    const val COMMONS_IO = "2.19.0"
 }

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionConfig.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionConfig.kt
@@ -1,0 +1,37 @@
+package com.manage.crm.config.web.compression
+
+import com.manage.crm.config.web.compression.gzip.GzipCompressionFilter
+import com.manage.crm.config.web.compression.gzip.GzipDecompressionFilter
+import com.manage.crm.config.web.compression.properties.CompressionUrlProperties
+import com.manage.crm.config.web.compression.properties.DecompressionRequestProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CompressionConfig {
+    @Bean
+    @ConfigurationProperties(prefix = "server.compression.url")
+    fun compressionUrlProperties(): CompressionUrlProperties {
+        return CompressionUrlProperties()
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "server.decompression.request")
+    fun decompressionRequestProperties(): DecompressionRequestProperties {
+        return DecompressionRequestProperties()
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "server.compression.url", name = ["enabled"], havingValue = "true")
+    fun gzipCompressionFilter(properties: CompressionUrlProperties): GzipCompressionFilter {
+        return GzipCompressionFilter(properties)
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "server.decompression.request", name = ["enabled"], havingValue = "true")
+    fun gzipDeCompressionFilter(): GzipDecompressionFilter {
+        return GzipDecompressionFilter()
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionConfig.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionConfig.kt
@@ -31,7 +31,7 @@ class CompressionConfig {
 
     @Bean
     @ConditionalOnProperty(prefix = "server.decompression.request", name = ["enabled"], havingValue = "true")
-    fun gzipDeCompressionFilter(): GzipDecompressionFilter {
+    fun gzipDecompressionFilter(): GzipDecompressionFilter {
         return GzipDecompressionFilter()
     }
 }

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionException.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionException.kt
@@ -1,0 +1,13 @@
+package com.manage.crm.config.web.compression
+
+class IllegalCompressionRequestException : RuntimeException {
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+class IllegalCompressionResponseException : RuntimeException {
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+class CompressionException

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionHttpObject.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionHttpObject.kt
@@ -1,6 +1,8 @@
 package com.manage.crm.config.web.compression
 
+import com.manage.crm.config.web.compression.gzip.GzipCompressionUtils.Companion.GZIP
 import com.manage.crm.config.web.compression.properties.CompressionUrlProperties
+import org.springframework.http.HttpHeaders
 import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator
 
@@ -20,6 +22,14 @@ abstract class CompressionHttpResponse(
 
     fun isResponseSizeValid(size: Long): Boolean {
         return size >= minResponseSize
+    }
+
+    fun setCompressionHeaders(encoding: String) {
+        delegate.headers.vary.add(HttpHeaders.ACCEPT_ENCODING)
+        // Remove any existing Content-Length header to enable chunked transfer
+        delegate.headers.remove(HttpHeaders.CONTENT_LENGTH)
+        // Set the Content-Encoding header to indicate that the response is compressed
+        delegate.headers[HttpHeaders.CONTENT_ENCODING] = listOf(GZIP)
     }
 }
 

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionHttpObject.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/CompressionHttpObject.kt
@@ -1,0 +1,26 @@
+package com.manage.crm.config.web.compression
+
+import com.manage.crm.config.web.compression.properties.CompressionUrlProperties
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator
+
+abstract class CompressionHttpResponse(
+    delegate: ServerHttpResponse,
+    private val properties: CompressionUrlProperties,
+    private val minResponseSize: Int = properties.minResponseSize
+) : ServerHttpResponseDecorator(delegate) {
+    fun isMimeTypeMatches(): Boolean {
+        return delegate.headers.contentType?.let { type ->
+            properties.mimeTypes.any { mt ->
+                val mimeType = type.toString()
+                mimeType == mt || mimeType.startsWith("$mt;") || mt.endsWith("/*") && mimeType.startsWith(mt.dropLast(1))
+            }
+        } ?: false
+    }
+
+    fun isResponseSizeValid(size: Long): Boolean {
+        return size >= minResponseSize
+    }
+}
+
+class CompressionHttpObject

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipCompressionFilter.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipCompressionFilter.kt
@@ -1,0 +1,67 @@
+package com.manage.crm.config.web.compression.gzip
+
+import com.manage.crm.config.web.compression.IllegalCompressionResponseException
+import com.manage.crm.config.web.compression.gzip.GzipCompressionUtils.Companion.isGzipResponseRequired
+import com.manage.crm.config.web.compression.properties.CompressionUrlProperties
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+class GzipCompressionFilter(
+    private val properties: CompressionUrlProperties
+) : WebFilter {
+    private val log = KotlinLogging.logger {}
+    private val pathMatcher = AntPathMatcher()
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        // Skip if URL-based compression is disabled
+        if (!properties.enabled) {
+            return chain.filter(exchange)
+        }
+
+        val request = exchange.request
+        val path = request.uri.path
+
+        // Check if the request path matches any of the configured patterns
+        val shouldCompress = properties.patterns.any { pattern ->
+            pathMatcher.match(pattern, path)
+        }
+
+        // Skip if the path doesn't match any pattern or client doesn't accept gzip
+        if (!shouldCompress || !isGzipResponseRequired(request)) {
+            return chain.filter(exchange)
+        }
+
+        // Create a decorated response that will compress the body
+        val gzipServerHttpResponse = GzipServerHttpResponse(exchange.response, properties)
+        val gzipExchange = exchange.mutate()
+            .response(gzipServerHttpResponse)
+            .build()
+
+        return chain.filter(gzipExchange)
+            .onErrorResume { ex: Throwable ->
+                when (ex) {
+                    is IllegalCompressionResponseException -> {
+                        log.error { "Gzip Compression failed: ${ex.message}" }
+                        exchange.response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR
+                        exchange.response.writeWith(
+                            Mono.just(
+                                exchange.response.bufferFactory().wrap("Gzip Compression failed ${ex.message}".toByteArray())
+                            )
+                        )
+                    }
+                    else -> {
+                        log.error { "Gzip Compression failed: ${ex.message}" }
+                        Mono.error(ex)
+                    }
+                }
+            }
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipCompressionUtils.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipCompressionUtils.kt
@@ -27,8 +27,6 @@ class GzipCompressionUtils {
             return containsGzip(serverHttpRequest, CONTENT_ENCODING).also {
                 if (it) {
                     log.debug { "Gzip decompression enabled for request" }
-                } else {
-                    log.debug { "Gzip decompression not enabled for request" }
                 }
             }
         }
@@ -37,8 +35,6 @@ class GzipCompressionUtils {
             return containsGzip(serverHttpRequest, ACCEPT_ENCODING).also {
                 if (it) {
                     log.debug { "Gzip compression enabled for response" }
-                } else {
-                    log.debug { "Gzip compression not enabled for response" }
                 }
             }
         }

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipCompressionUtils.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipCompressionUtils.kt
@@ -1,0 +1,90 @@
+package com.manage.crm.config.web.compression.gzip
+
+import com.manage.crm.config.web.compression.IllegalCompressionResponseException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.commons.io.IOUtils
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferFactory
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpHeaders.ACCEPT_ENCODING
+import org.springframework.http.HttpHeaders.CONTENT_ENCODING
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.util.CollectionUtils.isEmpty
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+class GzipCompressionUtils {
+    companion object {
+        val log = KotlinLogging.logger {}
+        const val GZIP = "gzip"
+
+        fun isGzipRequest(serverHttpRequest: ServerHttpRequest): Boolean {
+            return containsGzip(serverHttpRequest, CONTENT_ENCODING).also {
+                if (it) {
+                    log.debug { "Gzip decompression enabled for request" }
+                } else {
+                    log.debug { "Gzip decompression not enabled for request" }
+                }
+            }
+        }
+
+        fun isGzipResponseRequired(serverHttpRequest: ServerHttpRequest): Boolean {
+            return containsGzip(serverHttpRequest, ACCEPT_ENCODING).also {
+                if (it) {
+                    log.debug { "Gzip compression enabled for response" }
+                } else {
+                    log.debug { "Gzip compression not enabled for response" }
+                }
+            }
+        }
+
+        private fun containsGzip(serverHttpRequest: ServerHttpRequest, headerName: String): Boolean {
+            val headers: HttpHeaders = serverHttpRequest.headers
+            if (!isEmpty(headers)) {
+                val header = headers.getFirst(headerName)
+                return header?.contains(GZIP) ?: false
+            }
+            return false
+        }
+
+        fun decompress(bytes: ByteArray): DataBuffer {
+            log.debug { "Gzip decompression enabled for request" }
+            return try {
+                ByteArrayInputStream(bytes).use { inputStream ->
+                    GZIPInputStream(inputStream).use { gzipInputStream ->
+                        DefaultDataBufferFactory.sharedInstance.wrap(decompress(gzipInputStream))
+                    }
+                }
+            } catch (e: IOException) {
+                throw IllegalCompressionResponseException("Failed to decompress gzip content: ${e.message}", e)
+            }
+        }
+
+        private fun decompress(inputStream: InputStream?): ByteArray {
+            return inputStream?.let { IOUtils.toByteArray(it) } ?: ByteArray(0)
+        }
+
+        fun compress(dataBufferFactory: DataBufferFactory, bytes: ByteArray): DataBuffer {
+            log.debug { "Gzip compression enabled for response" }
+            return dataBufferFactory.wrap(compress(bytes))
+        }
+
+        private fun compress(bytes: ByteArray): ByteArray {
+            return try {
+                ByteArrayOutputStream().use { outputStream ->
+                    GZIPOutputStream(outputStream).use { gzipOutputStream ->
+                        gzipOutputStream.write(bytes)
+                    }
+                    outputStream.toByteArray()
+                }
+            } catch (e: IOException) {
+                throw IllegalCompressionResponseException("Failed to compress data: ${e.message}", e)
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipDecompressionFilter.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipDecompressionFilter.kt
@@ -1,0 +1,33 @@
+package com.manage.crm.config.web.compression.gzip
+
+import com.manage.crm.config.web.compression.gzip.GzipCompressionUtils.Companion.isGzipRequest
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class GzipDecompressionFilter : WebFilter {
+    private val log = KotlinLogging.logger {}
+
+    override fun filter(serverWebExchange: ServerWebExchange, webFilterChain: WebFilterChain): Mono<Void> {
+        if (!isGzipRequest(serverWebExchange.request)) return webFilterChain.filter(serverWebExchange)
+        log.debug { "Detected gzip encoded request, applying decompression" }
+
+        val gzipServerHttpRequest = GzipServerHttpRequest(serverWebExchange.request)
+        return serverWebExchange
+            .mutate()
+            .request(gzipServerHttpRequest)
+            .build()
+            .let {
+                webFilterChain
+                    .filter(it)
+                    .doOnError { ex: Throwable ->
+                        log.error(ex) { "Gzip decompressed HTTP request failed" }
+                    }
+            }
+    }
+}

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipServerHttpObject.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipServerHttpObject.kt
@@ -1,0 +1,72 @@
+package com.manage.crm.config.web.compression.gzip
+
+import com.manage.crm.config.web.compression.CompressionHttpResponse
+import com.manage.crm.config.web.compression.gzip.GzipCompressionUtils.Companion.GZIP
+import com.manage.crm.config.web.compression.gzip.GzipCompressionUtils.Companion.compress
+import com.manage.crm.config.web.compression.gzip.GzipCompressionUtils.Companion.decompress
+import com.manage.crm.config.web.compression.properties.CompressionUrlProperties
+import org.reactivestreams.Publisher
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
+import org.springframework.http.HttpHeaders
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator
+import org.springframework.http.server.reactive.ServerHttpResponse
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+class GzipServerHttpRequest(
+    delegate: ServerHttpRequest
+) : ServerHttpRequestDecorator(delegate) {
+
+    override fun getBody(): Flux<DataBuffer> {
+        return DataBufferUtils.join(super.getBody())
+            .flatMapMany { joined ->
+                val bytes = readByte(joined)
+                Flux.just(decompress(bytes))
+            }
+    }
+}
+
+class GzipServerHttpResponse(
+    delegate: ServerHttpResponse,
+    properties: CompressionUrlProperties
+) : CompressionHttpResponse(delegate, properties) {
+    override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void> {
+        // Skip if the response is not gzip compatible
+        if (!isMimeTypeMatches()) {
+            return super.writeWith(body)
+        }
+
+        // Remove any existing Content-Length header to enable chunked transfer
+        delegate.headers.remove(HttpHeaders.CONTENT_LENGTH)
+
+        return Mono.defer {
+            DataBufferUtils.join(body)
+                .flatMap { joined ->
+                    val bytes = readByte(joined)
+                    val buffer = if (isResponseSizeValid(bytes.size.toLong())) {
+                        delegate.headers[HttpHeaders.CONTENT_ENCODING] = listOf(GZIP)
+                        compress(delegate.bufferFactory(), bytes)
+                    } else {
+                        delegate.bufferFactory().wrap(bytes)
+                    }
+                    super.writeWith(Mono.just(buffer))
+                }
+        }
+    }
+}
+
+// read the byte array from the DataBuffer and release the buffer
+private fun readByte(buffer: DataBuffer): ByteArray {
+    return try {
+        val count = buffer.readableByteCount()
+        if (count <= 0) return ByteArray(0)
+        val bytes = ByteArray(count)
+        buffer.read(bytes)
+        bytes
+    } finally {
+        DataBufferUtils.release(buffer)
+    }
+}
+class GzipServerHttpObject

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipServerHttpObject.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipServerHttpObject.kt
@@ -8,7 +8,6 @@ import com.manage.crm.config.web.compression.properties.CompressionUrlProperties
 import org.reactivestreams.Publisher
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils
-import org.springframework.http.HttpHeaders
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator
 import org.springframework.http.server.reactive.ServerHttpResponse
@@ -43,10 +42,7 @@ class GzipServerHttpResponse(
                 .flatMap { joined ->
                     val bytes = readByte(joined)
                     val buffer = if (isResponseSizeValid(bytes.size.toLong())) {
-                        // Remove any existing Content-Length header to enable chunked transfer
-                        delegate.headers.remove(HttpHeaders.CONTENT_LENGTH)
-                        // Set the Content-Encoding header to indicate that the response is compressed
-                        delegate.headers[HttpHeaders.CONTENT_ENCODING] = listOf(GZIP)
+                        setCompressionHeaders(GZIP)
                         compress(delegate.bufferFactory(), bytes)
                     } else {
                         delegate.bufferFactory().wrap(bytes)

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipServerHttpObject.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/gzip/GzipServerHttpObject.kt
@@ -38,14 +38,14 @@ class GzipServerHttpResponse(
             return super.writeWith(body)
         }
 
-        // Remove any existing Content-Length header to enable chunked transfer
-        delegate.headers.remove(HttpHeaders.CONTENT_LENGTH)
-
         return Mono.defer {
             DataBufferUtils.join(body)
                 .flatMap { joined ->
                     val bytes = readByte(joined)
                     val buffer = if (isResponseSizeValid(bytes.size.toLong())) {
+                        // Remove any existing Content-Length header to enable chunked transfer
+                        delegate.headers.remove(HttpHeaders.CONTENT_LENGTH)
+                        // Set the Content-Encoding header to indicate that the response is compressed
                         delegate.headers[HttpHeaders.CONTENT_ENCODING] = listOf(GZIP)
                         compress(delegate.bufferFactory(), bytes)
                     } else {

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/properties/CompressionUrlProperties.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/properties/CompressionUrlProperties.kt
@@ -1,0 +1,8 @@
+package com.manage.crm.config.web.compression.properties
+
+data class CompressionUrlProperties(
+    var enabled: Boolean = false,
+    var patterns: List<String> = emptyList(),
+    var minResponseSize: Int = 1024,
+    var mimeTypes: List<String> = listOf("application/json", "application/*+json")
+)

--- a/backend/src/main/kotlin/com/manage/crm/config/web/compression/properties/DecompressionRequestProperties.kt
+++ b/backend/src/main/kotlin/com/manage/crm/config/web/compression/properties/DecompressionRequestProperties.kt
@@ -1,0 +1,5 @@
+package com.manage.crm.config.web.compression.properties
+
+data class DecompressionRequestProperties(
+    var enabled: Boolean = false
+)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,18 @@
 # application.yml has only common properties
+server:
+    compression:
+        url:
+            enabled: true
+            patterns:
+                - "/api/**"
+            min-response-size: 1024
+            mime-types:
+                - "application/json"
+                - "application/*+json"
+    decompression:
+        request:
+            enabled: true
+
 spring:
     profiles:
         group:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 서버에서 HTTP 요청 바디의 gzip 압축 해제 및 HTTP 응답 바디의 gzip 압축 기능이 추가되었습니다.
    - 응답 압축은 `/api/**` 경로에 대해 최소 1024바이트 이상, 지정된 MIME 타입(`application/json`, `application/*+json`)에 적용됩니다.
    - 요청 압축 해제는 전역적으로 활성화되어 gzip으로 압축된 요청을 자동으로 처리합니다.
    - URL 패턴과 MIME 타입 기반의 동적 gzip 압축 및 해제 필터가 도입되었습니다.
    - 압축 관련 예외 처리 및 로그 기능이 강화되었습니다.
- **설정**
    - 압축 및 압축 해제 관련 서버 설정이 `application.yml`에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->