### PR TITLE
[Refactor/#85]  afterCommit, afterCompletion 시점 조정

### DIFF
--- a/backend/src/main/kotlin/com/manage/crm/email/support/EmailEventPublisher.kt
+++ b/backend/src/main/kotlin/com/manage/crm/email/support/EmailEventPublisher.kt
@@ -43,7 +43,7 @@ class EmailEventPublisher(
 
     suspend fun publishEvent(events: List<PostEmailTemplateEvent>) {
         events.parMap { event ->
-            transactionSynchronizationTemplate.afterCompletion(
+            transactionSynchronizationTemplate.afterCommit(
                 Dispatchers.IO + MDCContext(),
                 blockDescription = "publish event: $event"
             ) {

--- a/backend/src/main/kotlin/com/manage/crm/event/application/PostCampaignUseCase.kt
+++ b/backend/src/main/kotlin/com/manage/crm/event/application/PostCampaignUseCase.kt
@@ -45,7 +45,7 @@ class PostCampaignUseCase(
             )
         )
 
-        transactionSynchronizationTemplate.afterCompletion(Dispatchers.IO, "save campaign cache") {
+        transactionSynchronizationTemplate.afterCommit(Dispatchers.IO, "save campaign cache") {
             campaignCacheManager.save(savedCampaign)
         }
 

--- a/backend/src/main/kotlin/com/manage/crm/user/support/UserEventPublisher.kt
+++ b/backend/src/main/kotlin/com/manage/crm/user/support/UserEventPublisher.kt
@@ -17,7 +17,7 @@ class UserEventPublisher(
     val log = KotlinLogging.logger {}
 
     suspend fun publishEvent(event: NewUserEvent) {
-        transactionSynchronizationTemplate.afterCompletion(
+        transactionSynchronizationTemplate.afterCommit(
             Dispatchers.Default + MDCContext(),
             "publish event: $event"
         ) {

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
@@ -71,7 +71,7 @@ class PostCampaignUseCaseTest : BehaviorSpec({
             coEvery { campaignCacheManager.save(any()) } answers { savedCampaign }
 
             coEvery {
-                transactionSynchronizationTemplate.afterCompletion(
+                transactionSynchronizationTemplate.afterCommit(
                     eq(Dispatchers.IO),
                     eq("save campaign cache"),
                     captureLambda<suspend () -> Unit>()
@@ -98,7 +98,7 @@ class PostCampaignUseCaseTest : BehaviorSpec({
 
             then("register transaction synchronization after completion for save campaign cache") {
                 coVerify(exactly = 1) {
-                    transactionSynchronizationTemplate.afterCompletion(
+                    transactionSynchronizationTemplate.afterCommit(
                         eq(Dispatchers.IO),
                         eq("save campaign cache"),
                         captureLambda<suspend () -> Unit>()
@@ -142,7 +142,7 @@ class PostCampaignUseCaseTest : BehaviorSpec({
 
             then("not called register transaction synchronization after completion for save campaign cache") {
                 coVerify(exactly = 0) {
-                    transactionSynchronizationTemplate.afterCompletion(
+                    transactionSynchronizationTemplate.afterCommit(
                         eq(Dispatchers.IO),
                         eq("save campaign cache"),
                         captureLambda<suspend () -> Unit>()

--- a/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
+++ b/backend/src/test/kotlin/com/manage/crm/event/application/PostCampaignUseCaseTest.kt
@@ -96,7 +96,7 @@ class PostCampaignUseCaseTest : BehaviorSpec({
                 coVerify(exactly = 1) { campaignRepository.save(any()) }
             }
 
-            then("register transaction synchronization after completion for save campaign cache") {
+            then("register transaction synchronization after commit for save campaign cache") {
                 coVerify(exactly = 1) {
                     transactionSynchronizationTemplate.afterCommit(
                         eq(Dispatchers.IO),
@@ -140,7 +140,7 @@ class PostCampaignUseCaseTest : BehaviorSpec({
                 coVerify(exactly = 0) { campaignRepository.save(any(Campaign::class)) }
             }
 
-            then("not called register transaction synchronization after completion for save campaign cache") {
+            then("not called register transaction synchronization after commit for save campaign cache") {
                 coVerify(exactly = 0) {
                     transactionSynchronizationTemplate.afterCommit(
                         eq(Dispatchers.IO),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 트랜잭션이 성공적으로 커밋된 후에만 이벤트 발행 및 캐시 저장 작업이 실행되도록 변경하여, 롤백된 트랜잭션에서 불필요한 작업이 발생하지 않도록 개선되었습니다.

- **테스트**
	- 트랜잭션 커밋 후 동작을 검증하도록 테스트 코드가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->